### PR TITLE
Fix SO3 initialisation and update more non_const access to unit_quaternion

### DIFF
--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -345,8 +345,8 @@ public:
 
   inline
   SE3Group()
+      : translation_( TranslationType::Zero() )
   {
-    translation_.setZero();
   }
 
   template<typename OtherDerived> inline

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -265,8 +265,8 @@ public:
   inline
   void setQuaternion(const QuaternionType& quaternion) {
     assert(quaternion.norm()!=static_cast<Scalar>(0));
-    unit_quaternion() = quaternion;
-    unit_quaternion().normalize();
+    unit_quaternion_nonconst() = quaternion;
+    unit_quaternion_nonconst().normalize();
   }
 
   template<typename NewScalarType>
@@ -312,8 +312,8 @@ public:
 
   inline SO3Group()
     // Initialize Quaternion to identity rotation
-    : unit_quaternion_(static_cast<Scalar>(0), static_cast<Scalar>(0),
-                       static_cast<Scalar>(0), static_cast<Scalar>(1)) {
+    : unit_quaternion_(static_cast<Scalar>(1), static_cast<Scalar>(0),
+                       static_cast<Scalar>(0), static_cast<Scalar>(0)) {
   }
 
   template<typename OtherDerived> inline


### PR DESCRIPTION
This update fixes the problem I was having. It turns out I was relying on default construction which was broken when you changed the default constructor for SO3. This update fixes the scalar order so SO3 is default identity constructed.
