### PR TITLE
fixed namespace pollution ("using namespace Eigen/std" in headers")

### DIFF
--- a/sophus/rxso3.hpp
+++ b/sophus/rxso3.hpp
@@ -68,7 +68,6 @@ struct traits<Map<const Sophus::RxSO3Group<_Scalar>, _Options> >
 }
 
 namespace Sophus {
-using namespace Eigen;
 
 class ScaleNotPositive : public SophusException {
 public:
@@ -98,12 +97,12 @@ template<typename Derived>
 class RxSO3GroupBase {
 public:
   /** \brief scalar type, use with care since this might be a Map type  */
-  typedef typename internal::traits<Derived>::Scalar Scalar;
+  typedef typename Eigen::internal::traits<Derived>::Scalar Scalar;
   /** \brief quaternion reference type */
-  typedef typename internal::traits<Derived>::QuaternionType &
+  typedef typename Eigen::internal::traits<Derived>::QuaternionType &
   QuaternionReference;
   /** \brief quaternion const reference type */
-  typedef const typename internal::traits<Derived>::QuaternionType &
+  typedef const typename Eigen::internal::traits<Derived>::QuaternionType &
   ConstQuaternionReference;
 
 
@@ -116,13 +115,13 @@ public:
   /** \brief group transformations are NxN matrices */
   static const int N = 3;
   /** \brief group transfomation type */
-  typedef Matrix<Scalar,N,N> Transformation;
+  typedef Eigen::Matrix<Scalar,N,N> Transformation;
   /** \brief point type */
-  typedef Matrix<Scalar,3,1> Point;
+  typedef Eigen::Matrix<Scalar,3,1> Point;
   /** \brief tangent vector type */
-  typedef Matrix<Scalar,DoF,1> Tangent;
+  typedef Eigen::Matrix<Scalar,DoF,1> Tangent;
   /** \brief adjoint transformation type */
-  typedef Matrix<Scalar,DoF,DoF> Adjoint;
+  typedef Eigen::Matrix<Scalar,DoF,DoF> Adjoint;
 
 
   /**
@@ -222,7 +221,7 @@ public:
   const Transformation matrix() const {
     //ToDO: implement this directly!
     Scalar scale = quaternion().norm();
-    Quaternion<Scalar> norm_quad = quaternion();
+    Eigen::Quaternion<Scalar> norm_quad = quaternion();
     norm_quad.coeffs() /= scale;
     return scale*norm_quad.toRotationMatrix();
   }
@@ -263,7 +262,7 @@ public:
   const Point operator*(const Point & p) const {
     //ToDO: implement this directly!
     Scalar scale = quaternion().norm();
-    Quaternion<Scalar> norm_quad = quaternion();
+    Eigen::Quaternion<Scalar> norm_quad = quaternion();
     norm_quad.coeffs() /= scale;
     return scale*norm_quad._transformVector(p);
   }
@@ -299,7 +298,7 @@ public:
   inline
   Transformation rotationMatrix() const {
     Scalar scale = quaternion().norm();
-    Quaternion<Scalar> norm_quad = quaternion();
+    Eigen::Quaternion<Scalar> norm_quad = quaternion();
     norm_quad.coeffs() /= scale;
     return norm_quad.toRotationMatrix();
   }
@@ -415,10 +414,10 @@ public:
   inline static
   const RxSO3Group<Scalar> expAndTheta(const Tangent & a,
                                        Scalar * theta) {
-    const Matrix<Scalar,3,1> & omega = a.template head<3>();
+    const Eigen::Matrix<Scalar,3,1> & omega = a.template head<3>();
     Scalar sigma = a[3];
     Scalar scale = std::exp(sigma);
-    Quaternion<Scalar> quat
+    Eigen::Quaternion<Scalar> quat
         = SO3Group<Scalar>::expAndTheta(omega, theta).unit_quaternion();
     quat.coeffs() *= scale;
     return RxSO3Group<Scalar>(quat);
@@ -509,9 +508,9 @@ public:
   inline static
   const Tangent lieBracket(const Tangent & a,
                            const Tangent & b) {
-    const Matrix<Scalar,3,1> & omega1 = a.template head<3>();
-    const Matrix<Scalar,3,1> & omega2 = b.template head<3>();
-    Matrix<Scalar,4,1> res;
+    const Eigen::Matrix<Scalar,3,1> & omega1 = a.template head<3>();
+    const Eigen::Matrix<Scalar,3,1> & omega2 = b.template head<3>();
+    Eigen::Matrix<Scalar,4,1> res;
     res.template head<3>() = omega1.cross(omega2);
     res[3] = static_cast<Scalar>(0);
     return res;
@@ -589,13 +588,13 @@ class RxSO3Group : public RxSO3GroupBase<RxSO3Group<_Scalar,_Options> > {
   typedef RxSO3GroupBase<RxSO3Group<_Scalar,_Options> > Base;
 public:
   /** \brief scalar type */
-  typedef typename internal::traits<SO3Group<_Scalar,_Options> >
+  typedef typename Eigen::internal::traits<SO3Group<_Scalar,_Options> >
   ::Scalar Scalar;
   /** \brief quaternion reference type */
-  typedef typename internal::traits<SO3Group<_Scalar,_Options> >
+  typedef typename Eigen::internal::traits<SO3Group<_Scalar,_Options> >
   ::QuaternionType & QuaternionReference;
   /** \brief quaternion const reference type */
-  typedef const typename internal::traits<SO3Group<_Scalar,_Options> >
+  typedef const typename Eigen::internal::traits<SO3Group<_Scalar,_Options> >
   ::QuaternionType & ConstQuaternionReference;
 
   /** \brief degree of freedom of group */
@@ -680,7 +679,7 @@ public:
    * \pre quaternion must not be zero
    */
   inline explicit
-  RxSO3Group(const Quaternion<Scalar> & quat) : quaternion_(quat) {
+  RxSO3Group(const Eigen::Quaternion<Scalar> & quat) : quaternion_(quat) {
     if(quaternion_.squaredNorm() <= SophusConstants<Scalar>::epsilon()) {
       throw ScaleNotPositive();
     }
@@ -703,7 +702,7 @@ public:
   }
 
 protected:
-  Quaternion<Scalar> quaternion_;
+  Eigen::Quaternion<Scalar> quaternion_;
 };
 
 } // end namespace

--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -70,8 +70,6 @@ struct traits<Map<const Sophus::SE2Group<_Scalar>, _Options> >
 }
 
 namespace Sophus {
-using namespace Eigen;
-using namespace std;
 
 /**
  * \brief SE2 base type - implements SE2 class but is storage agnostic
@@ -82,18 +80,18 @@ template<typename Derived>
 class SE2GroupBase {
 public:
   /** \brief scalar type */
-  typedef typename internal::traits<Derived>::Scalar Scalar;
+  typedef typename Eigen::internal::traits<Derived>::Scalar Scalar;
   /** \brief translation reference type */
-  typedef typename internal::traits<Derived>::TranslationType &
+  typedef typename Eigen::internal::traits<Derived>::TranslationType &
   TranslationReference;
   /** \brief translation const reference type */
-  typedef const typename internal::traits<Derived>::TranslationType &
+  typedef const typename Eigen::internal::traits<Derived>::TranslationType &
   ConstTranslationReference;
   /** \brief SO2 reference type */
-  typedef typename internal::traits<Derived>::SO2Type &
+  typedef typename Eigen::internal::traits<Derived>::SO2Type &
   SO2Reference;
   /** \brief SO2 type */
-  typedef const typename internal::traits<Derived>::SO2Type &
+  typedef const typename Eigen::internal::traits<Derived>::SO2Type &
   ConstSO2Reference;
 
   /** \brief degree of freedom of group
@@ -105,13 +103,13 @@ public:
   /** \brief group transformations are NxN matrices */
   static const int N = 3;
   /** \brief group transfomation type */
-  typedef Matrix<Scalar,N,N> Transformation;
+  typedef Eigen::Matrix<Scalar,N,N> Transformation;
   /** \brief point type */
-  typedef Matrix<Scalar,2,1> Point;
+  typedef Eigen::Matrix<Scalar,2,1> Point;
   /** \brief tangent vector type */
-  typedef Matrix<Scalar,DoF,1> Tangent;
+  typedef Eigen::Matrix<Scalar,DoF,1> Tangent;
   /** \brief adjoint transformation type */
-  typedef Matrix<Scalar,DoF,DoF> Adjoint;
+  typedef Eigen::Matrix<Scalar,DoF,DoF> Adjoint;
 
   /**
    * \brief Adjoint transformation
@@ -123,7 +121,7 @@ public:
    */
   inline
   const Adjoint Adj() const {
-    const Matrix<Scalar,2,2> & R = so2().matrix();
+    const Eigen::Matrix<Scalar,2,2> & R = so2().matrix();
     Transformation res;
     res.setIdentity();
     res.template topLeftCorner<2,2>() = R;
@@ -208,8 +206,8 @@ public:
    * It returns the three first row of matrix().
    */
   inline
-  const Matrix<Scalar,2,3> matrix2x3() const {
-    Matrix<Scalar,2,3> matrix;
+  const Eigen::Matrix<Scalar,2,3> matrix2x3() const {
+    Eigen::Matrix<Scalar,2,3> matrix;
     matrix.block(0,0,2,2) = rotationMatrix();
     matrix.col(2) = translation();
     return matrix;
@@ -269,7 +267,7 @@ public:
    * \returns Rotation matrix
    */
   inline
-  const Matrix<Scalar,2,2> rotationMatrix() const {
+  const Eigen::Matrix<Scalar,2,2> rotationMatrix() const {
     return so2().matrix();
   }
 
@@ -282,7 +280,7 @@ public:
    * The complex number is normalized to unit length.
    */
   inline
-  void setComplex(const Matrix<Scalar,2,1> & complex) {
+  void setComplex(const Eigen::Matrix<Scalar,2,1> & complex) {
     return so2().setComplex(complex);
   }
 
@@ -293,7 +291,7 @@ public:
    * \pre     the 2x2 matrix should be orthogonal and have a determinant of 1
    */
   inline
-  void setRotationMatrix(const Matrix<Scalar,2,2> & R) {
+  void setRotationMatrix(const Eigen::Matrix<Scalar,2,2> & R) {
     so2().setComplex(static_cast<Scalar>(0.5)*(R(0,0)+R(1,1)),
                      static_cast<Scalar>(0.5)*(R(1,0)-R(0,1)));
   }
@@ -337,7 +335,7 @@ public:
    * normalized.
    */
   inline
-  typename internal::traits<Derived>::SO2Type::ConstComplexReference
+  typename Eigen::internal::traits<Derived>::SO2Type::ConstComplexReference
   unit_complex() const {
     return so2().unit_complex();
   }
@@ -358,7 +356,7 @@ public:
   inline static
   const Transformation d_lieBracketab_by_d_a(const Tangent & b) {
     static const Scalar zero = static_cast<Scalar>(0);
-    Matrix<Scalar,2,1> upsilon2 = b.template head<2>();
+    Eigen::Matrix<Scalar,2,1> upsilon2 = b.template head<2>();
     Scalar theta2 = b[2];
 
     Transformation res;
@@ -404,7 +402,7 @@ public:
       one_minus_cos_theta_by_theta
           = (static_cast<Scalar>(1.) - so2.unit_complex().x())/theta;
     }
-    Matrix<Scalar,2,1> trans
+    Eigen::Matrix<Scalar,2,1> trans
         (sin_theta_by_theta*a[0] - one_minus_cos_theta_by_theta*a[1],
         one_minus_cos_theta_by_theta * a[0]+sin_theta_by_theta*a[1]);
     return SE2Group<Scalar>(so2, trans);
@@ -489,8 +487,8 @@ public:
   inline static
   const Tangent lieBracket(const Tangent & a,
                            const Tangent & b) {
-    Matrix<Scalar,2,1> upsilon1 = a.template head<2>();
-    Matrix<Scalar,2,1> upsilon2 = b.template head<2>();
+    Eigen::Matrix<Scalar,2,1> upsilon1 = a.template head<2>();
+    Eigen::Matrix<Scalar,2,1> upsilon2 = b.template head<2>();
     Scalar theta1 = a[2];
     Scalar theta2 = b[2];
 
@@ -524,7 +522,7 @@ public:
     Scalar halftheta = static_cast<Scalar>(0.5)*theta;
     Scalar halftheta_by_tan_of_halftheta;
 
-    const Matrix<Scalar,2,1> & z = so2.unit_complex();
+    const Eigen::Matrix<Scalar,2,1> & z = so2.unit_complex();
     Scalar real_minus_one = z.x()-static_cast<Scalar>(1.);
     if (std::abs(real_minus_one)<SophusConstants<Scalar>::epsilon()) {
       halftheta_by_tan_of_halftheta
@@ -534,7 +532,7 @@ public:
       halftheta_by_tan_of_halftheta
           = -(halftheta*z.y())/(real_minus_one);
     }
-    Matrix<Scalar,2,2> V_inv;
+    Eigen::Matrix<Scalar,2,2> V_inv;
     V_inv <<  halftheta_by_tan_of_halftheta,                      halftheta
         ,                        -halftheta,  halftheta_by_tan_of_halftheta;
     upsilon_theta.template head<2>() = V_inv*other.translation();
@@ -570,18 +568,18 @@ class SE2Group : public SE2GroupBase<SE2Group<_Scalar,_Options> > {
 
 public:
   /** \brief scalar type */
-  typedef typename internal::traits<SE2Group<_Scalar,_Options> >
+  typedef typename Eigen::internal::traits<SE2Group<_Scalar,_Options> >
   ::Scalar Scalar;
   /** \brief translation reference type */
-  typedef typename internal::traits<SE2Group<_Scalar,_Options> >
+  typedef typename Eigen::internal::traits<SE2Group<_Scalar,_Options> >
   ::TranslationType & TranslationReference;
-  typedef const typename internal::traits<SE2Group<_Scalar,_Options> >
+  typedef const typename Eigen::internal::traits<SE2Group<_Scalar,_Options> >
   ::TranslationType & ConstTranslationReference;
   /** \brief SO2 reference type */
-  typedef typename internal::traits<SE2Group<_Scalar,_Options> >
+  typedef typename Eigen::internal::traits<SE2Group<_Scalar,_Options> >
   ::SO2Type & SO2Reference;
   /** \brief SO2 const reference type */
-  typedef const typename internal::traits<SE2Group<_Scalar,_Options> >
+  typedef const typename Eigen::internal::traits<SE2Group<_Scalar,_Options> >
   ::SO2Type & ConstSO2Reference;
 
   /** \brief degree of freedom of group */
@@ -609,7 +607,7 @@ public:
    */
   inline
   SE2Group()
-    : translation_( Matrix<Scalar,2,1>::Zero() )
+    : translation_(Eigen::Matrix<Scalar,2,1>::Zero())
   {
   }
 
@@ -733,7 +731,7 @@ public:
 
 protected:
   Sophus::SO2Group<Scalar> so2_;
-  Matrix<Scalar,2,1> translation_;
+  Eigen::Matrix<Scalar,2,1> translation_;
 };
 
 

--- a/sophus/sim3.hpp
+++ b/sophus/sim3.hpp
@@ -34,10 +34,10 @@ template<typename _Scalar, int _Options=0> class Sim3Group;
 typedef Sim3Group<double> Sim3 EIGEN_DEPRECATED;
 typedef Sim3Group<double> Sim3d; /**< double precision Sim3 */
 typedef Sim3Group<float> Sim3f;  /**< single precision Sim3 */
-typedef Matrix<double,7,1> Vector7d;
-typedef Matrix<double,7,7> Matrix7d;
-typedef Matrix<float,7,1> Vector7f;
-typedef Matrix<float,7,7> Matrix7f;
+typedef Eigen::Matrix<double,7,1> Vector7d;
+typedef Eigen::Matrix<double,7,7> Matrix7d;
+typedef Eigen::Matrix<float,7,1> Vector7f;
+typedef Eigen::Matrix<float,7,7> Matrix7f;
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -74,8 +74,6 @@ struct traits<Map<const Sophus::Sim3Group<_Scalar>, _Options> >
 }
 
 namespace Sophus {
-using namespace Eigen;
-using namespace std;
 
 /**
  * \brief Sim3 base type - implements Sim3 class but is storage agnostic
@@ -86,18 +84,18 @@ template<typename Derived>
 class Sim3GroupBase {
 public:
   /** \brief scalar type */
-  typedef typename internal::traits<Derived>::Scalar Scalar;
+  typedef typename Eigen::internal::traits<Derived>::Scalar Scalar;
   /** \brief translation reference type */
-  typedef typename internal::traits<Derived>::TranslationType &
+  typedef typename Eigen::internal::traits<Derived>::TranslationType &
   TranslationReference;
   /** \brief translation const reference type */
-  typedef const typename internal::traits<Derived>::TranslationType &
+  typedef const typename Eigen::internal::traits<Derived>::TranslationType &
   ConstTranslationReference;
   /** \brief RxSO3 reference type */
-  typedef typename internal::traits<Derived>::RxSO3Type &
+  typedef typename Eigen::internal::traits<Derived>::RxSO3Type &
   RxSO3Reference;
   /** \brief RxSO3 const reference type */
-  typedef const typename internal::traits<Derived>::RxSO3Type &
+  typedef const typename Eigen::internal::traits<Derived>::RxSO3Type &
   ConstRxSO3Reference;
 
 
@@ -110,13 +108,13 @@ public:
   /** \brief group transformations are NxN matrices */
   static const int N = 4;
   /** \brief group transfomation type */
-  typedef Matrix<Scalar,N,N> Transformation;
+  typedef Eigen::Matrix<Scalar,N,N> Transformation;
   /** \brief point type */
-  typedef Matrix<Scalar,3,1> Point;
+  typedef Eigen::Matrix<Scalar,3,1> Point;
   /** \brief tangent vector type */
-  typedef Matrix<Scalar,DoF,1> Tangent;
+  typedef Eigen::Matrix<Scalar,DoF,1> Tangent;
   /** \brief adjoint transformation type */
-  typedef Matrix<Scalar,DoF,DoF> Adjoint;
+  typedef Eigen::Matrix<Scalar,DoF,DoF> Adjoint;
 
   /**
    * \brief Adjoint transformation
@@ -128,7 +126,7 @@ public:
    */
   inline
   const Adjoint Adj() const {
-    const Matrix<Scalar,3,3> & R = rxso3().rotationMatrix();
+    const Eigen::Matrix<Scalar,3,3> & R = rxso3().rotationMatrix();
     Adjoint res;
     res.setZero();
     res.block(0,0,3,3) = scale()*R;
@@ -203,8 +201,8 @@ public:
    * It returns the three first row of matrix().
    */
   inline
-  const Matrix<Scalar,3,4> matrix3x4() const {
-    Matrix<Scalar,3,4> matrix;
+  const Eigen::Matrix<Scalar,3,4> matrix3x4() const {
+    Eigen::Matrix<Scalar,3,4> matrix;
     matrix.block(0,0,3,3) = rxso3().matrix();
     matrix.col(3) = translation();
     return matrix;
@@ -263,7 +261,7 @@ public:
    * \brief Mutator of quaternion
    */
   inline
-  typename internal::traits<Derived>::RxSO3Type::QuaternionReference
+  typename Eigen::internal::traits<Derived>::RxSO3Type::QuaternionReference
   quaternion() {
     return rxso3().quaternion();
   }
@@ -272,7 +270,7 @@ public:
    * \brief Accessor of quaternion
    */
   inline
-  typename internal::traits<Derived>::RxSO3Type::ConstQuaternionReference
+  typename Eigen::internal::traits<Derived>::RxSO3Type::ConstQuaternionReference
   quaternion() const {
     return rxso3().quaternion();
   }
@@ -291,7 +289,7 @@ public:
    * \returns Rotation matrix
    */
   inline
-  const Matrix<Scalar,3,3> rotationMatrix() const {
+  const Eigen::Matrix<Scalar,3,3> rotationMatrix() const {
     return rxso3().rotationMatrix();
   }
 
@@ -327,7 +325,7 @@ public:
    */
   inline
   void setRotationMatrix
-  (const Matrix<Scalar,3,3> & R) {
+  (const Eigen::Matrix<Scalar,3,3> & R) {
     rxso3().setRotationMatrix(R);
   }
 
@@ -348,7 +346,7 @@ public:
    */
   inline
   void setScaledRotationMatrix
-  (const Matrix<Scalar,3,3> & sR) {
+  (const Eigen::Matrix<Scalar,3,3> & sR) {
     rxso3().setScaledRotationMatrix(sR);
   }
 
@@ -383,14 +381,14 @@ public:
    */
   inline static
   const Adjoint d_lieBracketab_by_d_a(const Tangent & b) {
-    const Matrix<Scalar,3,1> & upsilon2 = b.template head<3>();
-    const Matrix<Scalar,3,1> & omega2 = b.template segment<3>(3);
+    const Eigen::Matrix<Scalar,3,1> & upsilon2 = b.template head<3>();
+    const Eigen::Matrix<Scalar,3,1> & omega2 = b.template segment<3>(3);
     Scalar sigma2 = b[6];
 
     Adjoint res;
     res.setZero();
     res.template topLeftCorner<3,3>()
-        = -SO3::hat(omega2)-sigma2*Matrix3d::Identity();
+        = -SO3::hat(omega2)-sigma2*Eigen::Matrix3d::Identity();
     res.template block<3,3>(0,3) = -SO3::hat(upsilon2);
     res.template topRightCorner<3,1>() = upsilon2;
     res.template block<3,3>(3,3) = -SO3::hat(omega2);
@@ -416,14 +414,14 @@ public:
    */
   inline static
   const Sim3Group<Scalar> exp(const Tangent & a) {
-    const Matrix<Scalar,3,1> & upsilon = a.segment(0,3);
-    const Matrix<Scalar,3,1> & omega = a.segment(3,3);
+    const Eigen::Matrix<Scalar,3,1> & upsilon = a.segment(0,3);
+    const Eigen::Matrix<Scalar,3,1> & omega = a.segment(3,3);
     Scalar sigma = a[6];
     Scalar theta;
     RxSO3Group<Scalar> rxso3
         = RxSO3Group<Scalar>::expAndTheta(a.template tail<4>(), &theta);
-    const Matrix<Scalar,3,3> & Omega = SO3Group<Scalar>::hat(omega);
-    const Matrix<Scalar,3,3> & W = calcW(theta, sigma, rxso3.scale(), Omega);
+    const Eigen::Matrix<Scalar,3,3> & Omega = SO3Group<Scalar>::hat(omega);
+    const Eigen::Matrix<Scalar,3,3> & W = calcW(theta, sigma, rxso3.scale(), Omega);
     return Sim3Group<Scalar>(rxso3, W*upsilon);
   }
 
@@ -534,10 +532,10 @@ public:
   inline static
   const Tangent lieBracket(const Tangent & a,
                            const Tangent & b) {
-    const Matrix<Scalar,3,1> & upsilon1 = a.template head<3>();
-    const Matrix<Scalar,3,1> & upsilon2 = b.template head<3>();
-    const Matrix<Scalar,3,1> & omega1 = a.template segment<3>(3);
-    const Matrix<Scalar,3,1> & omega2 = b.template segment<3>(3);
+    const Eigen::Matrix<Scalar,3,1> & upsilon1 = a.template head<3>();
+    const Eigen::Matrix<Scalar,3,1> & upsilon2 = b.template head<3>();
+    const Eigen::Matrix<Scalar,3,1> & omega1 = a.template segment<3>(3);
+    const Eigen::Matrix<Scalar,3,1> & omega2 = b.template segment<3>(3);
     Scalar sigma1 = a[6];
     Scalar sigma2 = b[6];
 
@@ -572,11 +570,11 @@ public:
   const Tangent log(const Sim3Group<Scalar> & other) {
     Tangent res;
     Scalar theta;
-    const Matrix<Scalar,4,1> & omega_sigma
+    const Eigen::Matrix<Scalar,4,1> & omega_sigma
         = RxSO3Group<Scalar>::logAndTheta(other.rxso3(), &theta);
-    const Matrix<Scalar,3,1> & omega = omega_sigma.template head<3>();
+    const Eigen::Matrix<Scalar,3,1> & omega = omega_sigma.template head<3>();
     Scalar sigma = omega_sigma[3];
-    const Matrix<Scalar,3,3> & W
+    const Eigen::Matrix<Scalar,3,3> & W
         = calcW(theta, sigma, other.scale(), SO3Group<Scalar>::hat(omega));
     res.segment(0,3) = W.partialPivLu().solve(other.translation());
     res.segment(3,3) = omega;
@@ -606,15 +604,15 @@ public:
 
 private:
   static
-  Matrix<Scalar,3,3> calcW(const Scalar & theta,
-                           const Scalar & sigma,
-                           const Scalar & scale,
-                           const Matrix<Scalar,3,3> & Omega){
-    static const Matrix<Scalar,3,3> I
-        = Matrix<Scalar,3,3>::Identity();
+  Eigen::Matrix<Scalar,3,3> calcW(const Scalar & theta,
+                                  const Scalar & sigma,
+                                  const Scalar & scale,
+                                  const Eigen::Matrix<Scalar,3,3> & Omega){
+    static const Eigen::Matrix<Scalar,3,3> I
+        = Eigen::Matrix<Scalar,3,3>::Identity();
     static const Scalar one = static_cast<Scalar>(1.);
     static const Scalar half = static_cast<Scalar>(1./2.);
-    Matrix<Scalar,3,3> Omega2 = Omega*Omega;
+    Eigen::Matrix<Scalar,3,3> Omega2 = Omega*Omega;
 
     Scalar A,B,C;
     if (std::abs(sigma)<SophusConstants<Scalar>::epsilon()) {
@@ -654,19 +652,19 @@ class Sim3Group : public Sim3GroupBase<Sim3Group<_Scalar,_Options> > {
   typedef Sim3GroupBase<Sim3Group<_Scalar,_Options> > Base;
 public:
   /** \brief scalar type */
-  typedef typename internal::traits<Sim3Group<_Scalar,_Options> >
+  typedef typename Eigen::internal::traits<Sim3Group<_Scalar,_Options> >
   ::Scalar Scalar;
   /** \brief RxSO3 reference type */
-  typedef typename internal::traits<Sim3Group<_Scalar,_Options> >
+  typedef typename Eigen::internal::traits<Sim3Group<_Scalar,_Options> >
   ::RxSO3Type & RxSO3Reference;
   /** \brief RxSO3 const reference type */
-  typedef const typename internal::traits<Sim3Group<_Scalar,_Options> >
+  typedef const typename Eigen::internal::traits<Sim3Group<_Scalar,_Options> >
   ::RxSO3Type & ConstRxSO3Reference;
   /** \brief translation reference type */
-  typedef typename internal::traits<Sim3Group<_Scalar,_Options> >
+  typedef typename Eigen::internal::traits<Sim3Group<_Scalar,_Options> >
   ::TranslationType & TranslationReference;
   /** \brief translation const reference type */
-  typedef const typename internal::traits<Sim3Group<_Scalar,_Options> >
+  typedef const typename Eigen::internal::traits<Sim3Group<_Scalar,_Options> >
   ::TranslationType & ConstTranslationReference;
 
   /** \brief degree of freedom of group */
@@ -694,7 +692,7 @@ public:
    */
   inline
   Sim3Group()
-    : translation_( Matrix<Scalar,3,1>::Zero() )
+    : translation_(Eigen::Matrix<Scalar,3,1>::Zero())
   {
   }
 
@@ -721,7 +719,7 @@ public:
    * \pre quaternion must not be zero
    */
   inline
-  Sim3Group(const Quaternion<Scalar> & quaternion,
+  Sim3Group(const Eigen::Quaternion<Scalar> & quaternion,
             const Point & translation)
     : rxso3_(quaternion), translation_(translation) {
   }
@@ -798,7 +796,7 @@ public:
 
 protected:
   Sophus::RxSO3Group<Scalar> rxso3_;
-  Matrix<Scalar,3,1> translation_;
+  Eigen::Matrix<Scalar,3,1> translation_;
 };
 
 

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -73,7 +73,6 @@ struct traits<Map<const Sophus::SO2Group<_Scalar>, _Options> >
 }
 
 namespace Sophus {
-using namespace Eigen;
 
 /**
  * \brief SO2 base type - implements SO2 class but is storage agnostic
@@ -84,12 +83,12 @@ template<typename Derived>
 class SO2GroupBase {
 public:
   /** \brief scalar type */
-  typedef typename internal::traits<Derived>::Scalar Scalar;
+  typedef typename Eigen::internal::traits<Derived>::Scalar Scalar;
   /** \brief complex number reference type */
-  typedef typename internal::traits<Derived>::ComplexType &
+  typedef typename Eigen::internal::traits<Derived>::ComplexType &
   ComplexReference;
   /** \brief complex number const reference type */
-  typedef const typename internal::traits<Derived>::ComplexType &
+  typedef const typename Eigen::internal::traits<Derived>::ComplexType &
   ConstComplexReference;
 
   /** \brief degree of freedom of group
@@ -101,9 +100,9 @@ public:
   /** \brief group transformations are NxN matrices */
   static const int N = 2;
   /** \brief group transfomation type */
-  typedef Matrix<Scalar,N,N> Transformation;
+  typedef Eigen::Matrix<Scalar,N,N> Transformation;
   /** \brief point type */
-  typedef Matrix<Scalar,2,1> Point;
+  typedef Eigen::Matrix<Scalar,2,1> Point;
   /** \brief tangent vector type */
   typedef Scalar Tangent;
   /** \brief adjoint transformation type */
@@ -437,13 +436,13 @@ class SO2Group : public SO2GroupBase<SO2Group<_Scalar,_Options> > {
   typedef SO2GroupBase<SO2Group<_Scalar,_Options> > Base;
 public:
   /** \brief scalar type */
-  typedef typename internal::traits<SO2Group<_Scalar,_Options> >
+  typedef typename Eigen::internal::traits<SO2Group<_Scalar,_Options> >
   ::Scalar Scalar;
   /** \brief complex number reference type */
-  typedef typename internal::traits<SO2Group<_Scalar,_Options> >
+  typedef typename Eigen::internal::traits<SO2Group<_Scalar,_Options> >
   ::ComplexType & ComplexReference;
   /** \brief complex number const reference type */
-  typedef const typename internal::traits<SO2Group<_Scalar,_Options> >
+  typedef const typename Eigen::internal::traits<SO2Group<_Scalar,_Options> >
   ::ComplexType & ConstComplexReference;
 
   /** \brief degree of freedom of group */
@@ -514,7 +513,7 @@ public:
    * \pre vector must not be zero
    */
   inline explicit
-  SO2Group(const Matrix<Scalar,2,1> & complex)
+  SO2Group(const Eigen::Matrix<Scalar,2,1> & complex)
     : unit_complex_(complex) {
     Base::normalize();
   }
@@ -561,7 +560,7 @@ protected:
     return (real*real + imag*imag < SophusConstants<Scalar>::epsilon());
   }
 
-  Matrix<Scalar,2,1> unit_complex_;
+  Eigen::Matrix<Scalar,2,1> unit_complex_;
 };
 
 } // end namespace

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -68,7 +68,6 @@ struct traits<Map<const Sophus::SO3Group<_Scalar>, _Options> >
 }
 
 namespace Sophus {
-using namespace Eigen;
 
 /**
  * \brief SO3 base type - implements SO3 class but is storage agnostic
@@ -79,12 +78,12 @@ template<typename Derived>
 class SO3GroupBase {
 public:
   /** \brief scalar type */
-  typedef typename internal::traits<Derived>::Scalar Scalar;
+  typedef typename Eigen::internal::traits<Derived>::Scalar Scalar;
   /** \brief quaternion reference type  */
-  typedef typename internal::traits<Derived>::QuaternionType &
+  typedef typename Eigen::internal::traits<Derived>::QuaternionType &
   QuaternionReference;
   /** \brief quaternion const reference type  */
-  typedef const typename internal::traits<Derived>::QuaternionType &
+  typedef const typename Eigen::internal::traits<Derived>::QuaternionType &
   ConstQuaternionReference;
 
   /** \brief degree of freedom of group
@@ -96,13 +95,13 @@ public:
   /** \brief group transformations are NxN matrices */
   static const int N = 3;
   /** \brief group transfomation type */
-  typedef Matrix<Scalar,N,N> Transformation;
+  typedef Eigen::Matrix<Scalar,N,N> Transformation;
   /** \brief point type */
-  typedef Matrix<Scalar,3,1> Point;
+  typedef Eigen::Matrix<Scalar,3,1> Point;
   /** \brief tangent vector type */
-  typedef Matrix<Scalar,DoF,1> Tangent;
+  typedef Eigen::Matrix<Scalar,DoF,1> Tangent;
   /** \brief adjoint transformation type */
-  typedef Matrix<Scalar,DoF,DoF> Adjoint;
+  typedef Eigen::Matrix<Scalar,DoF,DoF> Adjoint;
 
   /**
    * \brief Adjoint transformation
@@ -277,7 +276,7 @@ public:
    * The quaternion is normalized to unit length.
    */
   inline
-  void setQuaternion(const Quaternion<Scalar>& quaternion) {
+  void setQuaternion(const Eigen::Quaternion<Scalar>& quaternion) {
     unit_quaternion_nonconst() = quaternion;
     normalize();
   }
@@ -362,7 +361,7 @@ public:
       real_factor = std::cos(half_theta);
     }
 
-    return SO3Group<Scalar>(Quaternion<Scalar>(real_factor,
+    return SO3Group<Scalar>(Eigen::Quaternion<Scalar>(real_factor,
                                                imag_factor*omega.x(),
                                                imag_factor*omega.y(),
                                                imag_factor*omega.z()));
@@ -566,12 +565,12 @@ class SO3Group : public SO3GroupBase<SO3Group<_Scalar,_Options> > {
   typedef SO3GroupBase<SO3Group<_Scalar,_Options> > Base;
 public:
   /** \brief scalar type */
-  typedef typename internal::traits<SO3Group<_Scalar,_Options> >
+  typedef typename Eigen::internal::traits<SO3Group<_Scalar,_Options> >
   ::Scalar Scalar;
   /** \brief quaternion type */
-  typedef typename internal::traits<SO3Group<_Scalar,_Options> >
+  typedef typename Eigen::internal::traits<SO3Group<_Scalar,_Options> >
   ::QuaternionType & QuaternionReference;
-  typedef const typename internal::traits<SO3Group<_Scalar,_Options> >
+  typedef const typename Eigen::internal::traits<SO3Group<_Scalar,_Options> >
   ::QuaternionType & ConstQuaternionReference;
 
   /** \brief degree of freedom of group */
@@ -628,7 +627,7 @@ public:
    * \pre quaternion must not be zero
    */
   inline explicit
-  SO3Group(const Quaternion<Scalar> & quat) : unit_quaternion_(quat) {
+  SO3Group(const Eigen::Quaternion<Scalar> & quat) : unit_quaternion_(quat) {
     Base::normalize();
   }
 
@@ -674,7 +673,7 @@ protected:
     return unit_quaternion_;
   }
 
-  Quaternion<Scalar> unit_quaternion_;
+  Eigen::Quaternion<Scalar> unit_quaternion_;
 };
 
 } // end namespace

--- a/sophus/sophus.hpp
+++ b/sophus/sophus.hpp
@@ -29,7 +29,6 @@
 #include <Eigen/Geometry>
 
 namespace Sophus {
-using namespace Eigen;
 
 template<typename Scalar>
 struct SophusConstants {


### PR DESCRIPTION
Thanks for sharing this useful library.

There is a problem with namespace pollution I ran into when using it in conjunction with another library that does not use Eigen but defines its own Matrix / Vector classes: Sophus has a few "using namespace Eigen" in its headers, which leads to conflicts.

This is also mentioned as item 59 in Alexandrescu's "C++ Coding Standards"
http://www.gotw.ca/publications/c++cs.htm

The commit below fixed this for me.