### PR TITLE
Avoiding side effect in exponential mapping calculation

### DIFF
--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -411,8 +411,7 @@ public:
     const SO3Group<Scalar> & so3
         = SO3Group<Scalar>::expAndTheta(omega, &theta);
 
-    const Matrix<Scalar,3,3> & Omega = SO3Group<Scalar>::hat(omega);
-    const Matrix<Scalar,3,3> & Omega_sq = Omega*Omega;
+    Matrix<Scalar,3,3> Omega = SO3Group<Scalar>::hat(omega);
     Matrix<Scalar,3,3> V;
 
     if(theta<SophusConstants<Scalar>::epsilon()) {
@@ -422,7 +421,7 @@ public:
       Scalar theta_sq = theta*theta;
       V = (Matrix<Scalar,3,3>::Identity()
            + (static_cast<Scalar>(1)-std::cos(theta))/(theta_sq)*Omega
-           + (theta-std::sin(theta))/(theta_sq*theta)*Omega_sq);
+           + (theta-std::sin(theta))/(theta_sq*theta)*(Omega*Omega));
     }
     return SE3Group<Scalar>(so3,V*a.template head<3>());
   }

--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -411,7 +411,7 @@ public:
     const SO3Group<Scalar> & so3
         = SO3Group<Scalar>::expAndTheta(omega, &theta);
 
-    Matrix<Scalar,3,3> Omega = SO3Group<Scalar>::hat(omega);
+    const Matrix<Scalar,3,3>& Omega = SO3Group<Scalar>::hat(omega);
     Matrix<Scalar,3,3> V;
 
     if(theta<SophusConstants<Scalar>::epsilon()) {


### PR DESCRIPTION
Hi guys,

Writing from Imperial College :).

While integrating LSD-SLAM (http://vision.in.tum.de/research/lsdslam) into SLAMBench (http://apt.cs.manchester.ac.uk/projects/PAMELA/tools/SLAMBench/) I ran into this weird issue. When compiling with optimisations disabled, the exponential mapping of SE3Group fails due to some unexpected side effect in the summation. I believe it is coming from a weird interaction between the constant reference to temporary objects and Eigen's operators. 

A possible fix is the one I'm proposing here, but please let me know if there is something that I might be overlooking. I appreciate performance-wise is better to avoid the copy I'm now introducing but hopefully it shouldn't be too penalising.

Bests,

Emanuele