### PR TITLE
Fix compilation error with setScaledRotationMatrix

### DIFF
--- a/sophus/rxso3.hpp
+++ b/sophus/rxso3.hpp
@@ -640,7 +640,7 @@ public:
    */
   inline explicit
   RxSO3Group(const Transformation & sR) {
-    setScaledRotationMatrix(sR);
+    this->setScaledRotationMatrix(sR);
   }
 
   /**

--- a/sophus/rxso3.hpp
+++ b/sophus/rxso3.hpp
@@ -21,7 +21,7 @@
 // IN THE SOFTWARE.
 
 #ifndef SOPHUS_RXSO3_HPP
-#define RXSO3_HPP
+#define SOPHUS_RXSO3_HPP
 
 #include "sophus.hpp"
 #include "so3.hpp"


### PR DESCRIPTION
Fixes the following error:

rxso3.hpp:643:31: error: ‘setScaledRotationMatrix’ was not declared in
this scope, and no declarations were found by argument-dependent lookup
at the point of instantiation [-fpermissive]
     setScaledRotationMatrix(sR);
rxso3.hpp:643:31: note: declarations in dependent base
‘Sophus::RxSO3GroupBase<Sophus::RxSO3Group<float>>’ are not found by unqualified lookup
rxso3.hpp:643:31: note: use ‘this->setScaledRotationMatrix’ instead