### PR TITLE
RxSO3 re-design

### DIFF
--- a/test/core/test_rxso3.cpp
+++ b/test/core/test_rxso3.cpp
@@ -82,7 +82,16 @@ void tests() {
   rxso3.setScale(scale);
   if (std::abs(scale - rxso3.scale()) > SophusConstants<Scalar>::epsilon()) {
     std::cerr << "setScale unit test failed." << std::endl;
-	std::exit(-1);
+    std::exit(-1);
+  }
+  Eigen::Matrix<Scalar, 3, 3> sR =
+      SO3Group<Scalar>::exp(Point(0.2, 0.5, -1.0)).matrix() * Scalar(1.3);
+  rxso3.setScaledRotationMatrix(sR);
+  if ((sR - rxso3.matrix()).norm() > SophusConstants<Scalar>::epsilon()) {
+    std::cerr << "setScaleRotationMatrix unit test failed." << std::endl;
+    std::cerr << sR << "\nversus\n";
+    std::cerr << rxso3.matrix() << std::endl;
+    std::exit(-1);
   }
 }
 


### PR DESCRIPTION
 - scale is now represented as quaternion.squaredNorm(); a lot of functions are more efficient since std::sqrt is only called in a few places now
 - matrix() and operator* are reimplemented from scratch
 - added explicit class invariant that the scale must be >= eps
 - group multiplication using saturation so that it obeys class invariant