### PR TITLE
Fix ISO C99 GCC rest error for SOPHUS_ENSURE

### DIFF
--- a/sophus/common.hpp
+++ b/sophus/common.hpp
@@ -95,7 +95,7 @@ inline std::string FormatString() { return std::string(); }
 
 #if defined(SOPHUS_DISABLE_ENSURES)
 
-#define SOPHUS_ENSURE(expr, description, ...) ((void)0)
+#define SOPHUS_ENSURE(expr, ...) ((void)0)
 
 #elif defined(SOPHUS_ENABLE_ENSURE_HANDLER)
 


### PR DESCRIPTION
Currently, the `SOPHUS_ENSURE` macro uses the gcc extension `##` before `VA_ARGS` to remove the leading comma when `VA_ARGS` is empty.

This gcc extension is not part of iso C99, which causes gcc to give this warning 
`warning: ISO C99 requires rest arguments to be used when called with the flags --pedantic and --std=c99.`

This would in general be safe to ignore, but I am working within a project that has some very strict compilation rules, and treats the warning as errors.

A simple solution is to include the description argument inside the "..." variadic arguments, such that there is always at least one argument as part of the ellipsis.

https://github.com/alvaroabascar/caballa/issues/1
https://stackoverflow.com/questions/4100746/suppressing-iso-c99-requires-rest-arguments-to-be-used