### PR TITLE
set Quaternion coefficients to 0 before setting generator element

### DIFF
--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -347,6 +347,7 @@ class SO3Base {
     SOPHUS_ENSURE(internal_gen_q != NULL,
                   "internal_gen_q must not be the null pointer");
     // Factor of 0.5 since SU(2) is a double cover of SO(3).
+    internal_gen_q->coeffs().setZero();
     internal_gen_q->coeffs()[i] = Scalar(0.5);
   }
 


### PR DESCRIPTION
fixes uninitialized Quaternion in SO3::internalGenerator()