### PR TITLE
Adding group actions on lines

### DIFF
--- a/sophus/rxso2.hpp
+++ b/sophus/rxso2.hpp
@@ -84,6 +84,7 @@ class RxSO2Base {
   static int constexpr N = 2;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector2<Scalar>;
+  using Line = ParametrizedLine2<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
@@ -179,6 +180,18 @@ class RxSO2Base {
   //   ``p_bar = s * (bar_R_foo * p_foo)``.
   //
   SOPHUS_FUNC Point operator*(Point const& p) const { return matrix() * p; }
+
+  // Group action on lines.
+  //
+  // This function rotates a parametrized line ``l(t) = o + t * d`` by the SO2
+  // element and scales it by the scale factor
+  //
+  // Origin ``o`` is rotated and scaled
+  // Direction ``d`` is rotated (preserving it's norm)
+  //
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    return Line((*this) * l.origin(), (*this) * l.direction() / scale());
+  }
 
   // In-place group multiplication.
   //

--- a/sophus/rxso3.hpp
+++ b/sophus/rxso3.hpp
@@ -76,6 +76,7 @@ class RxSO3Base {
   static int constexpr N = 3;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector3<Scalar>;
+  using Line = ParametrizedLine3<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
@@ -200,6 +201,19 @@ class RxSO3Base {
     two_vec_cross_p += two_vec_cross_p;
     return scale * p + (quaternion().w() * two_vec_cross_p +
                         quaternion().vec().cross(two_vec_cross_p));
+  }
+
+  // Group action on lines.
+  //
+  // This function rotates a parametrized line ``l(t) = o + t * d`` by the SO3
+  // element ans scales it by the scale factor:
+  //
+  // Origin ``o`` is rotated and scaled
+  // Direction ``d`` is rotated (preserving it's norm)
+  //
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    return Line((*this) * l.origin(),
+                (*this) * l.direction() / quaternion().squaredNorm());
   }
 
   // In-place group multiplication.

--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -68,6 +68,7 @@ class SE2Base {
   static int constexpr N = 3;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector2<Scalar>;
+  using Line = ParametrizedLine2<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
@@ -169,6 +170,18 @@ class SE2Base {
   //
   SOPHUS_FUNC Point operator*(Point const& p) const {
     return so2() * p + translation();
+  }
+
+  // Group action on lines.
+  //
+  // This function rotates and translates a parametrized line
+  // ``l(t) = o + t * d`` by the SE(2) element:
+  //
+  // Origin ``o`` is rotated and translated using SE(2) action
+  // Direction ``d`` is rotated using SO(2) action
+  //
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    return Line((*this) * l.origin(), so2() * l.direction());
   }
 
   // In-place group multiplication.

--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -69,6 +69,7 @@ class SE3Base {
   static int constexpr N = 4;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector3<Scalar>;
+  using Line = ParametrizedLine3<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
   // Adjoint transformation
@@ -196,6 +197,18 @@ class SE3Base {
   //
   SOPHUS_FUNC Point operator*(Point const& p) const {
     return so3() * p + translation();
+  }
+
+  // Group action on lines.
+  //
+  // This function rotates and translates a parametrized line
+  // ``l(t) = o + t * d`` by the SE(3) element:
+  //
+  // Origin is transformed using SE(3) action
+  // Direction is transformed using rotation part
+  //
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    return Line((*this) * l.origin(), so3() * l.direction());
   }
 
   // In-place group multiplication.

--- a/sophus/sim2.hpp
+++ b/sophus/sim2.hpp
@@ -71,6 +71,7 @@ class Sim2Base {
   static int constexpr N = 3;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector2<Scalar>;
+  using Line = ParametrizedLine2<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
@@ -173,6 +174,19 @@ class Sim2Base {
   //
   SOPHUS_FUNC Point operator*(Point const& p) const {
     return rxso2() * p + translation();
+  }
+
+  // Group action on lines.
+  //
+  // This function rotates, scales and translates a parametrized line
+  // ``l(t) = o + t * d`` by the Sim(2) element:
+  //
+  // Origin ``o`` is rotated, scaled and translated
+  // Direction ``d`` is rotated
+  //
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    Line rotatedLine = rxso2() * l;
+    return Line(rotatedLine.origin() + translation(), rotatedLine.direction());
   }
 
   // In-place group multiplication.

--- a/sophus/sim3.hpp
+++ b/sophus/sim3.hpp
@@ -72,6 +72,7 @@ class Sim3Base {
   static int constexpr N = 4;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector3<Scalar>;
+  using Line = ParametrizedLine3<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
@@ -174,6 +175,19 @@ class Sim3Base {
   //
   SOPHUS_FUNC Point operator*(Point const& p) const {
     return rxso3() * p + translation();
+  }
+
+  // Group action on lines.
+  //
+  // This function rotates, scales and translates a parametrized line
+  // ``l(t) = o + t * d`` by the Sim(3) element:
+  //
+  // Origin ``o`` is rotated, scaled and translated
+  // Direction ``d`` is rotated
+  //
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    Line rotatedLine = rxso3() * l;
+    return Line(rotatedLine.origin() + translation(), rotatedLine.direction());
   }
 
   // In-place group multiplication.

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -84,6 +84,7 @@ class SO2Base {
   static int constexpr N = 2;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector2<Scalar>;
+  using Line = ParametrizedLine2<Scalar>;
   using Tangent = Scalar;
   using Adjoint = Scalar;
 
@@ -183,6 +184,17 @@ class SO2Base {
     Scalar const& real = unit_complex().x();
     Scalar const& imag = unit_complex().y();
     return Point(real * p[0] - imag * p[1], imag * p[0] + real * p[1]);
+  }
+
+  // Group action on lines.
+  //
+  // This function rotates a parametrized line ``l(t) = o + t * d`` by the SO3
+  // element:
+  //
+  // Both direction ``d`` and origin ``o`` are rotated as a 3 dimensional point
+  //
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    return Line((*this) * l.origin(), (*this) * l.direction());
   }
 
   // In-place group multiplication.

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -81,6 +81,7 @@ class SO3Base {
   static int constexpr N = 3;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector3<Scalar>;
+  using Line = ParametrizedLine3<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
@@ -206,6 +207,17 @@ class SO3Base {
   //
   SOPHUS_FUNC Point operator*(Point const& p) const {
     return unit_quaternion()._transformVector(p);
+  }
+
+  // Group action on lines.
+  //
+  // This function rotates a parametrized line ``l(t) = o + t * d`` by the SO3
+  // element:
+  //
+  // Both direction ``d`` and origin ``o`` are rotated as a 3 dimensional point
+  //
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    return Line((*this) * l.origin(), (*this) * l.direction());
   }
 
   // In-place group multiplication.

--- a/sophus/types.hpp
+++ b/sophus/types.hpp
@@ -61,6 +61,19 @@ using Matrix7 = Matrix<Scalar, 7, 7>;
 using Matrix7f = Matrix7<float>;
 using Matrix7d = Matrix7<double>;
 
+template <class Scalar, int N, int Options = 0>
+using ParametrizedLine = Eigen::ParametrizedLine<Scalar, N, Options>;
+
+template <class Scalar, int Options = 0>
+using ParametrizedLine3 = ParametrizedLine<Scalar, 3, Options>;
+using ParametrizedLine3f = ParametrizedLine3<float>;
+using ParametrizedLine3d = ParametrizedLine3<double>;
+
+template <class Scalar, int Options = 0>
+using ParametrizedLine2 = ParametrizedLine<Scalar, 2, Options>;
+using ParametrizedLine2f = ParametrizedLine2<float>;
+using ParametrizedLine2d = ParametrizedLine2<double>;
+
 namespace details {
 template <class Scalar>
 class Metric {

--- a/test/core/test_rxso2.cpp
+++ b/test/core/test_rxso2.cpp
@@ -55,6 +55,7 @@ class Tests {
     tangent_vec_.push_back(tmp);
 
     point_vec_.push_back(Point(1, 4));
+    point_vec_.push_back(Point(1, -3));
   }
 
   void runAll() {

--- a/test/core/test_rxso3.cpp
+++ b/test/core/test_rxso3.cpp
@@ -56,6 +56,7 @@ class Tests {
     tangent_vec_.push_back(tmp);
 
     point_vec_.push_back(Point(1, 2, 4));
+    point_vec_.push_back(Point(1, -3, 0.5));
   }
 
   void runAll() {

--- a/test/core/test_se2.cpp
+++ b/test/core/test_se2.cpp
@@ -54,6 +54,7 @@ class Tests {
     tangent_vec_.push_back(tmp);
 
     point_vec_.push_back(Point(1, 2));
+    point_vec_.push_back(Point(1, -3));
   }
 
   void runAll() {

--- a/test/core/test_sim2.cpp
+++ b/test/core/test_sim2.cpp
@@ -66,6 +66,7 @@ class Tests {
     tangent_vec_.push_back(tmp);
 
     point_vec_.push_back(Point(1, 4));
+    point_vec_.push_back(Point(1, -3));
   }
 
   void runAll() {

--- a/test/core/test_sim3.cpp
+++ b/test/core/test_sim3.cpp
@@ -74,6 +74,7 @@ class Tests {
     tangent_vec_.push_back(tmp);
 
     point_vec_.push_back(Point(1, 2, 4));
+    point_vec_.push_back(Point(1, -3, 0.5));
   }
 
   void runAll() {

--- a/test/core/test_so2.cpp
+++ b/test/core/test_so2.cpp
@@ -42,6 +42,7 @@ class Tests {
     tangent_vec_.push_back(Tangent(kPi / 2. + 0.0001));
 
     point_vec_.push_back(Point(1, 2));
+    point_vec_.push_back(Point(1, -3));
   }
 
   void runAll() {

--- a/test/core/test_so3.cpp
+++ b/test/core/test_so3.cpp
@@ -48,6 +48,7 @@ class Tests {
     tangent_vec_.push_back(Tangent(30, 5, -1));
 
     point_vec_.push_back(Point(1, 2, 4));
+    point_vec_.push_back(Point(1, -3, 0.5));
   }
 
   void runAll() {

--- a/test/core/tests.hpp
+++ b/test/core/tests.hpp
@@ -19,6 +19,7 @@ class LieGroupTests {
   using Transformation = typename LieGroup::Transformation;
   using Tangent = typename LieGroup::Tangent;
   using Point = typename LieGroup::Point;
+  using Line = typename LieGroup::Line;
   using Adjoint = typename LieGroup::Adjoint;
   static int constexpr N = LieGroup::N;
   static int constexpr DoF = LieGroup::DoF;
@@ -88,6 +89,32 @@ class LieGroupTests {
         Point point2 = map(T, p);
         SOPHUS_TEST_APPROX(passed, point1, point2, kSmallEps,
                            "Transform point case: %", i);
+      }
+    }
+    return passed;
+  }
+
+  bool lineActionTest() {
+    bool passed = point_vec_.size() > 1;
+
+    for (size_t i = 0; i < group_vec_.size(); ++i) {
+      for (size_t j = 0; j + 1 < point_vec_.size(); ++j) {
+        Point const& p1 = point_vec_[j];
+        Point const& p2 = point_vec_[j + 1];
+        Line l = Line::Through(p1, p2);
+        Point p1_t = group_vec_[i] * p1;
+        Point p2_t = group_vec_[i] * p2;
+        Line l_t = group_vec_[i] * l;
+
+        SOPHUS_TEST_APPROX(passed, l_t.squaredDistance(p1_t),
+                           static_cast<Scalar>(0), kSmallEps,
+                           "Transform line case (1st point) : %", i);
+        SOPHUS_TEST_APPROX(passed, l_t.squaredDistance(p2_t),
+                           static_cast<Scalar>(0), kSmallEps,
+                           "Transform line case (2nd point) : %", i);
+        SOPHUS_TEST_APPROX(passed, l_t.direction().squaredNorm(),
+                           l.direction().squaredNorm(), kSmallEps,
+                           "Transform line case (direction) : %", i);
       }
     }
     return passed;
@@ -251,6 +278,7 @@ class LieGroupTests {
     passed &= expLogTest();
     passed &= expMapTest();
     passed &= groupActionTest();
+    passed &= lineActionTest();
     passed &= lieBracketTest();
     passed &= veeHatTest();
     passed &= newDeleteSmokeTest();


### PR DESCRIPTION
It seems reasonable to have group action on lines that acts compatible with group action on points.

I've added this group action as left-multiply Eigen::ParametrizedLine by the group element.
Multiplication implementation preserves direction norm (where applicable).

Test case checks that image of the line passing through two points passes through their images after applying transformations.