### PR TITLE
Added package.xml for catkin-tools compatibility

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>sophus</name>
+  <version>0.9.1</version>
+  <description>
+   C++ implementation of Lie Groups using Eigen.
+  </description>
+  <url type="repository">https://github.com/stonier/sophus</url>
+  <url type="bugtracker">https://github.com/stonier/sophus/issues</url>
+  <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
+  <author>Hauke Strasdat</author>
+  <license>BSD</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <build_depend>eigen</build_depend>
+
+  <exec_depend>catkin</exec_depend>
+  <exec_depend>eigen</exec_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+
+</package>

--- a/package.xml
+++ b/package.xml
@@ -2,13 +2,13 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>sophus</name>
-  <version>0.9.1</version>
+  <version>1.0.0</version>
   <description>
    C++ implementation of Lie Groups using Eigen.
   </description>
   <url type="repository">https://github.com/stonier/sophus</url>
   <url type="bugtracker">https://github.com/stonier/sophus/issues</url>
-  <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
+  <maintainer email="nomail@nomail.com">Hauke Strasdat</maintainer>
   <author>Hauke Strasdat</author>
   <license>BSD</license>
 

--- a/package.xml
+++ b/package.xml
@@ -6,18 +6,17 @@
   <description>
    C++ implementation of Lie Groups using Eigen.
   </description>
-  <url type="repository">https://github.com/stonier/sophus</url>
-  <url type="bugtracker">https://github.com/stonier/sophus/issues</url>
+  <url type="repository">https://github.com/strasdat/sophus</url>
+  <url type="bugtracker">https://github.com/strasdat/sophus/issues</url>
   <maintainer email="nomail@nomail.com">Hauke Strasdat</maintainer>
   <author>Hauke Strasdat</author>
   <license>BSD</license>
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <build_depend>eigen</build_depend>
+  <depend>eigen</depend>
 
   <exec_depend>catkin</exec_depend>
-  <exec_depend>eigen</exec_depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -1,25 +1,22 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>sophus</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>
    C++ implementation of Lie Groups using Eigen.
   </description>
   <url type="repository">https://github.com/strasdat/sophus</url>
   <url type="bugtracker">https://github.com/strasdat/sophus/issues</url>
-  <maintainer email="nomail@nomail.com">Hauke Strasdat</maintainer>
+  <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
   <author>Hauke Strasdat</author>
-  <license>BSD</license>
+  <license>MIT</license>
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <depend>eigen</depend>
-
-  <exec_depend>catkin</exec_depend>
+  <build_depend>eigen</build_depend>
+  <build_export_depend>eigen</build_export_depend>
 
   <export>
     <build_type>cmake</build_type>
   </export>
-
 </package>


### PR DESCRIPTION
This allows dropping the directory inside the catkin workspace and building with catkin-tools. I'm not sure if it is actually installable since it probably requires an install rule for package.xml which I'm not sure how to write. But it shouldn't be hard to find.