### PR TITLE
Extend operator* for Sophus types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ ENDIF()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
 
 # Find Eigen 3 (dependency)
-find_package(Eigen3 REQUIRED)
+find_package(Eigen3 3.3.0 REQUIRED)
 
 # Define interface library target
 add_library(sophus INTERFACE)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,17 +10,17 @@ platform: x64
 configuration: Release
 
 build:
-  project: c:\projects\sophus\build\Sophus.sln 
+  project: c:\projects\sophus\build\Sophus.sln
 
 install:
-  - ps: wget http://bitbucket.org/eigen/eigen/get/3.2.10.zip -outfile eigen3.zip
+  - ps: wget http://bitbucket.org/eigen/eigen/get/3.3.4.zip -outfile eigen3.zip
   - cmd: 7z x eigen3.zip -o"C:\projects" -y > nul
-  
+
 before_build:
   - cd c:\projects\sophus
   - mkdir build
   - cd build
-  - cmake -G "Visual Studio 14 2015 Win64" -D EIGEN3_INCLUDE_DIR=C:\projects\eigen-eigen-b9cd8366d4e8 ..
-  
+  - cmake -G "Visual Studio 14 2015 Win64" -D EIGEN3_INCLUDE_DIR=C:\projects\eigen-eigen-5a0156e40feb ..
+
 after_build:
   - ctest

--- a/sophus/rxso2.hpp
+++ b/sophus/rxso2.hpp
@@ -84,6 +84,7 @@ class RxSO2Base {
   static int constexpr N = 2;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector2<Scalar>;
+  using HomogeneousPoint = Vector3<Scalar>;
   using Line = ParametrizedLine2<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
@@ -101,6 +102,9 @@ class RxSO2Base {
 
   template <typename PointDerived>
   using PointProduct = Vector2<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector3<ReturnScalar<HPointDerived>>;
 
   // Adjoint transformation
   //
@@ -217,6 +221,17 @@ class RxSO2Base {
   SOPHUS_FUNC PointProduct<PointDerived> operator*(
       Eigen::MatrixBase<PointDerived> const& p) const {
     return matrix() * p;
+  }
+
+  // Group action on homogeneous 2-points. See above for more details.
+  //
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 3>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    const auto rsp = *this * p.template head<2>();
+    return HomogeneousPointProduct<HPointDerived>(rsp(0), rsp(1), p(2));
   }
 
   // Group action on lines.
@@ -357,6 +372,7 @@ class RxSO2 : public RxSO2Base<RxSO2<Scalar_, Options>> {
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
   using ComplexMember = Eigen::Matrix<Scalar, 2, 1, Options>;
@@ -566,6 +582,7 @@ class Map<Sophus::RxSO2<Scalar_>, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 
@@ -608,6 +625,7 @@ class Map<Sophus::RxSO2<Scalar_> const, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 

--- a/sophus/rxso3.hpp
+++ b/sophus/rxso3.hpp
@@ -76,6 +76,7 @@ class RxSO3Base {
   static int constexpr N = 3;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector3<Scalar>;
+  using HomogeneousPoint = Vector4<Scalar>;
   using Line = ParametrizedLine3<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
@@ -100,6 +101,9 @@ class RxSO3Base {
 
   template <typename PointDerived>
   using PointProduct = Vector3<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector4<ReturnScalar<HPointDerived>>;
 
   // Adjoint transformation
   //
@@ -253,6 +257,17 @@ class RxSO3Base {
                         quaternion().vec().cross(two_vec_cross_p));
   }
 
+  // Group action on homogeneous 3-points. See above for more details.
+  //
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 4>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    const auto rsp = *this * p.template head<3>();
+    return HomogeneousPointProduct<HPointDerived>(rsp(0), rsp(1), rsp(2), p(3));
+  }
+
   // Group action on lines.
   //
   // This function rotates a parametrized line ``l(t) = o + t * d`` by the SO3
@@ -395,6 +410,7 @@ class RxSO3 : public RxSO3Base<RxSO3<Scalar_, Options>> {
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
   using QuaternionMember = Eigen::Quaternion<Scalar, Options>;
@@ -636,6 +652,7 @@ class Map<Sophus::RxSO3<Scalar_>, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 
@@ -679,6 +696,7 @@ class Map<Sophus::RxSO3<Scalar_> const, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 

--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -68,6 +68,7 @@ class SE2Base {
   static int constexpr N = 3;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector2<Scalar>;
+  using HomogeneousPoint = Vector3<Scalar>;
   using Line = ParametrizedLine2<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
@@ -85,6 +86,9 @@ class SE2Base {
 
   template <typename PointDerived>
   using PointProduct = Vector2<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector3<ReturnScalar<HPointDerived>>;
 
   // Adjoint transformation
   //
@@ -246,6 +250,18 @@ class SE2Base {
     return so2() * p + translation();
   }
 
+  // Group action on homogeneous 2-points. See above for more details.
+  //
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 3>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    const PointProduct<HPointDerived> tp =
+        so2() * p.template head<2>() + p(2) * translation();
+    return HomogeneousPointProduct<HPointDerived>(tp(0), tp(1), p(2));
+  }
+
   // Group action on lines.
   //
   // This function rotates and translates a parametrized line
@@ -354,6 +370,7 @@ class SE2 : public SE2Base<SE2<Scalar_, Options>> {
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
   using SO2Member = SO2<Scalar, Options>;
@@ -731,6 +748,7 @@ class Map<Sophus::SE2<Scalar_>, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 
@@ -785,6 +803,7 @@ class Map<Sophus::SE2<Scalar_> const, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 

--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -69,6 +69,7 @@ class SE3Base {
   static int constexpr N = 4;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector3<Scalar>;
+  using HomogeneousPoint = Vector4<Scalar>;
   using Line = ParametrizedLine3<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
@@ -86,6 +87,9 @@ class SE3Base {
 
   template <typename PointDerived>
   using PointProduct = Vector3<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector4<ReturnScalar<HPointDerived>>;
 
   // Adjoint transformation
   //
@@ -320,6 +324,18 @@ class SE3Base {
     return so3() * p + translation();
   }
 
+  // Group action on homogeneous 3-points. See above for more details.
+  //
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 4>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    const PointProduct<HPointDerived> tp =
+        so3() * p.template head<3>() + p(3) * translation();
+    return HomogeneousPointProduct<HPointDerived>(tp(0), tp(1), tp(2), p(3));
+  }
+
   // Group action on lines.
   //
   // This function rotates and translates a parametrized line
@@ -418,6 +434,7 @@ class SE3 : public SE3Base<SE3<Scalar_, Options>> {
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
   using SO3Member = SO3<Scalar, Options>;
@@ -974,6 +991,7 @@ class Map<Sophus::SE3<Scalar_>, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 
@@ -1027,6 +1045,7 @@ class Map<Sophus::SE3<Scalar_> const, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 

--- a/sophus/sim2.hpp
+++ b/sophus/sim2.hpp
@@ -75,6 +75,20 @@ class Sim2Base {
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
+  // For binary operations the return type is determined with the
+  // ScalarBinaryOpTraits feature of Eigen. This allows mixing concrete and Map
+  // types, as well as other compatible scalar types such as Ceres::Jet and
+  // double scalars with SIM2 operations.
+  template <typename OtherDerived>
+  using ReturnScalar = typename Eigen::ScalarBinaryOpTraits<
+      Scalar, typename OtherDerived::Scalar>::ReturnType;
+
+  template <typename OtherDerived>
+  using Sim2Product = Sim2<ReturnScalar<OtherDerived>>;
+
+  template <typename PointDerived>
+  using PointProduct = Vector2<ReturnScalar<PointDerived>>;
+
   // Adjoint transformation
   //
   // This function return the adjoint transformation ``Ad`` of the group
@@ -187,8 +201,10 @@ class Sim2Base {
   // Note: That scaling is calculated with saturation. See RxSO2 for
   // details.
   //
-  SOPHUS_FUNC Sim2<Scalar> operator*(Sim2<Scalar> const& other) const {
-    Sim2<Scalar> result(*this);
+  template <typename OtherDerived>
+  SOPHUS_FUNC Sim2Product<OtherDerived> operator*(
+      Sim2Base<OtherDerived> const& other) const {
+    Sim2Product<OtherDerived> result(*this);
     result *= other;
     return result;
   }
@@ -201,7 +217,11 @@ class Sim2Base {
   //
   //   ``p_bar = bar_sR_foo * p_foo + t_bar``.
   //
-  SOPHUS_FUNC Point operator*(Point const& p) const {
+  template <typename PointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<PointDerived, 2>::value>::type>
+  SOPHUS_FUNC PointProduct<PointDerived> operator*(
+      Eigen::MatrixBase<PointDerived> const& p) const {
     return rxso2() * p + translation();
   }
 
@@ -229,9 +249,14 @@ class Sim2Base {
     return p;
   }
 
-  // In-place group multiplication.
+  // In-place group multiplication. This method is only valid if the return type
+  // of the multiplication is compatible with this SO2's Scalar type.
   //
-  SOPHUS_FUNC Sim2Base<Derived>& operator*=(Sim2<Scalar> const& other) {
+  template <typename OtherDerived,
+            typename = typename std::enable_if<
+                std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
+  SOPHUS_FUNC Sim2Base<Derived>& operator*=(
+      Sim2Base<OtherDerived> const& other) {
     translation() += (rxso2() * other.translation());
     rxso2() *= other.rxso2();
     return *this;

--- a/sophus/sim2.hpp
+++ b/sophus/sim2.hpp
@@ -71,6 +71,7 @@ class Sim2Base {
   static int constexpr N = 3;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector2<Scalar>;
+  using HomogeneousPoint = Vector3<Scalar>;
   using Line = ParametrizedLine2<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
@@ -88,6 +89,9 @@ class Sim2Base {
 
   template <typename PointDerived>
   using PointProduct = Vector2<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector3<ReturnScalar<HPointDerived>>;
 
   // Adjoint transformation
   //
@@ -225,6 +229,18 @@ class Sim2Base {
     return rxso2() * p + translation();
   }
 
+  // Group action on homogeneous 2-points. See above for more details.
+  //
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 3>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    const PointProduct<HPointDerived> tp =
+        rxso2() * p.template head<2>() + p(2) * translation();
+    return HomogeneousPointProduct<HPointDerived>(tp(0), tp(1), p(2));
+  }
+
   // Group action on lines.
   //
   // This function rotates, scales and translates a parametrized line
@@ -344,6 +360,7 @@ class Sim2 : public Sim2Base<Sim2<Scalar_, Options>> {
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
   using RxSo2Member = RxSO2<Scalar, Options>;
@@ -623,6 +640,7 @@ class Map<Sophus::Sim2<Scalar_>, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 
@@ -675,6 +693,7 @@ class Map<Sophus::Sim2<Scalar_> const, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 

--- a/sophus/sim3.hpp
+++ b/sophus/sim3.hpp
@@ -72,6 +72,7 @@ class Sim3Base {
   static int constexpr N = 4;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector3<Scalar>;
+  using HomogeneousPoint = Vector4<Scalar>;
   using Line = ParametrizedLine3<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
@@ -89,6 +90,9 @@ class Sim3Base {
 
   template <typename PointDerived>
   using PointProduct = Vector3<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector4<ReturnScalar<HPointDerived>>;
 
   // Adjoint transformation
   //
@@ -227,6 +231,18 @@ class Sim3Base {
     return rxso3() * p + translation();
   }
 
+  // Group action on homogeneous 3-points. See above for more details.
+  //
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 4>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    const PointProduct<HPointDerived> tp =
+        rxso3() * p.template head<3>() + p(3) * translation();
+    return HomogeneousPointProduct<HPointDerived>(tp(0), tp(1), tp(2), p(3));
+  }
+
   // Group action on lines.
   //
   // This function rotates, scales and translates a parametrized line
@@ -348,6 +364,7 @@ class Sim3 : public Sim3Base<Sim3<Scalar_, Options>> {
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
   using RxSo3Member = RxSO3<Scalar, Options>;
@@ -644,6 +661,7 @@ class Map<Sophus::Sim3<Scalar_>, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 
@@ -696,6 +714,7 @@ class Map<Sophus::Sim3<Scalar_> const, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -85,6 +85,7 @@ class SO2Base {
   static int constexpr N = 2;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector2<Scalar>;
+  using HomogeneousPoint = Vector3<Scalar>;
   using Line = ParametrizedLine2<Scalar>;
   using Tangent = Scalar;
   using Adjoint = Scalar;
@@ -102,6 +103,9 @@ class SO2Base {
 
   template <typename PointDerived>
   using PointProduct = Vector2<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector3<ReturnScalar<HPointDerived>>;
 
   // Adjoint transformation
   //
@@ -218,8 +222,24 @@ class SO2Base {
       Eigen::MatrixBase<PointDerived> const& p) const {
     Scalar const& real = unit_complex().x();
     Scalar const& imag = unit_complex().y();
-    return PointProduct<Point>(real * p[0] - imag * p[1],
-                               imag * p[0] + real * p[1]);
+    return PointProduct<PointDerived>(real * p[0] - imag * p[1],
+                                      imag * p[0] + real * p[1]);
+  }
+
+  // Group action on homogeneous 2-points.
+  //
+  // This function rotates a homogeneous 2 dimensional point ``p`` by the SO2
+  // element ``bar_R_foo`` (= rotation matrix): ``p_bar = bar_R_foo * p_foo``.
+  //
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 3>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    Scalar const& real = unit_complex().x();
+    Scalar const& imag = unit_complex().y();
+    return HomogeneousPointProduct<HPointDerived>(
+        real * p[0] - imag * p[1], imag * p[0] + real * p[1], p[2]);
   }
 
   // Group action on lines.
@@ -316,6 +336,7 @@ class SO2 : public SO2Base<SO2<Scalar_, Options>> {
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
   using ComplexMember = Vector2<Scalar, Options>;
@@ -524,6 +545,7 @@ class Map<Sophus::SO2<Scalar_>, Options>
 
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 
@@ -571,6 +593,7 @@ class Map<Sophus::SO2<Scalar_> const, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -93,6 +93,20 @@ class SO3Base {
     Scalar theta;
   };
 
+  // For binary operations the return type is determined with the
+  // ScalarBinaryOpTraits feature of Eigen. This allows mixing concrete and Map
+  // types, as well as other compatible scalar types such as Ceres::Jet and
+  // double scalars with SO3 operations.
+  template <typename OtherDerived>
+  using ReturnScalar = typename Eigen::ScalarBinaryOpTraits<
+      Scalar, typename OtherDerived::Scalar>::ReturnType;
+
+  template <typename OtherDerived>
+  using SO3Product = SO3<ReturnScalar<OtherDerived>>;
+
+  template <typename PointDerived>
+  using PointProduct = Vector3<ReturnScalar<PointDerived>>;
+
   // Adjoint transformation
   //
   // This function return the adjoint transformation ``Ad`` of the group
@@ -299,10 +313,21 @@ class SO3Base {
 
   // Group multiplication, which is rotation concatenation.
   //
-  SOPHUS_FUNC SO3<Scalar> operator*(SO3<Scalar> const& other) const {
-    SO3<Scalar> J(*this);
-    J *= other;
-    return J;
+  template <typename OtherDerived>
+  SOPHUS_FUNC SO3Product<OtherDerived> operator*(
+      SO3Base<OtherDerived> const& other) const {
+    using QuaternionProductType =
+        typename SO3Product<OtherDerived>::QuaternionType;
+    const QuaternionType& a = unit_quaternion();
+    const typename OtherDerived::QuaternionType& b = other.unit_quaternion();
+    // NOTE: We cannot use Eigen's Quaternion multiplication because it always
+    // returns a Quaternion of the same Scalar as this object, so it is not able
+    // to multiple Jets and doubles correctly.
+    return SO3Product<OtherDerived>(QuaternionProductType(
+        a.w() * b.w() - a.x() * b.x() - a.y() * b.y() - a.z() * b.z(),
+        a.w() * b.x() + a.x() * b.w() + a.y() * b.z() - a.z() * b.y(),
+        a.w() * b.y() + a.y() * b.w() + a.z() * b.x() - a.x() * b.z(),
+        a.w() * b.z() + a.z() * b.w() + a.x() * b.y() - a.y() * b.x()));
   }
 
   // Group action on 3-points.
@@ -319,8 +344,18 @@ class SO3Base {
   //
   // For ``vee``-operator, see below.
   //
-  SOPHUS_FUNC Point operator*(Point const& p) const {
-    return unit_quaternion()._transformVector(p);
+  template <typename PointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<PointDerived, 3>::value>::type>
+  SOPHUS_FUNC PointProduct<PointDerived> operator*(
+      Eigen::MatrixBase<PointDerived> const& p) const {
+    // NOTE: We cannot use Eigen's Quaternion transformVector because it always
+    // returns a Vector3 of the same Scalar as this quaternion, so it is not
+    // able to be applied to Jets and doubles correctly.
+    const QuaternionType& q = unit_quaternion();
+    PointProduct<PointDerived> uv = q.vec().cross(p);
+    uv += uv;
+    return p + q.w() * uv + q.vec().cross(uv);
   }
 
   // Group action on lines.
@@ -334,24 +369,14 @@ class SO3Base {
     return Line((*this) * l.origin(), (*this) * l.direction());
   }
 
-  // In-place group multiplication.
+  // In-place group multiplication. This method is only valid if the return type
+  // of the multiplication is compatible with this SO3's Scalar type.
   //
-  SOPHUS_FUNC SO3Base<Derived>& operator*=(SO3<Scalar> const& other) {
-    unit_quaternion_nonconst() *= other.unit_quaternion();
-
-    Scalar squared_norm = unit_quaternion().squaredNorm();
-
-    // We can assume that the squared-norm is close to 1 since we deal with a
-    // unit quaternion. Due to numerical precision issues, there might
-    // be a small drift after pose concatenation. Hence, we need to renormalizes
-    // the quaternion here.
-    // Since squared-norm is close to 1, we do not need to calculate the costly
-    // square-root, but can use an approximation around 1 (see
-    // http://stackoverflow.com/a/12934750 for details).
-    if (squared_norm != Scalar(1.0)) {
-      unit_quaternion_nonconst().coeffs() *=
-          Scalar(2.0) / (Scalar(1.0) + squared_norm);
-    }
+  template <typename OtherDerived,
+            typename = typename std::enable_if<
+                std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
+  SOPHUS_FUNC SO3Base<Derived>& operator*=(SO3Base<OtherDerived> const& other) {
+    *this = *this * other;
     return *this;
   }
 

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -82,6 +82,7 @@ class SO3Base {
   static int constexpr N = 3;
   using Transformation = Matrix<Scalar, N, N>;
   using Point = Vector3<Scalar>;
+  using HomogeneousPoint = Vector4<Scalar>;
   using Line = ParametrizedLine3<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
@@ -106,6 +107,9 @@ class SO3Base {
 
   template <typename PointDerived>
   using PointProduct = Vector3<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector4<ReturnScalar<HPointDerived>>;
 
   // Adjoint transformation
   //
@@ -358,6 +362,16 @@ class SO3Base {
     return p + q.w() * uv + q.vec().cross(uv);
   }
 
+  // Group action on homogeneous 3-points. See above for more details.
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 4>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    const auto rp = *this * p.template head<3>();
+    return HomogeneousPointProduct<HPointDerived>(rp(0), rp(1), rp(2), p(3));
+  }
+
   // Group action on lines.
   //
   // This function rotates a parametrized line ``l(t) = o + t * d`` by the SO3
@@ -416,6 +430,7 @@ class SO3 : public SO3Base<SO3<Scalar_, Options>> {
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
   using QuaternionMember = Eigen::Quaternion<Scalar, Options>;
@@ -754,6 +769,7 @@ class Map<Sophus::SO3<Scalar_>, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 
@@ -801,6 +817,7 @@ class Map<Sophus::SO3<Scalar_> const, Options>
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
   using Tangent = typename Base::Tangent;
   using Adjoint = typename Base::Adjoint;
 

--- a/sophus/types.hpp
+++ b/sophus/types.hpp
@@ -1,6 +1,7 @@
 #ifndef SOPHUS_TYEPES_HPP
 #define SOPHUS_TYEPES_HPP
 
+#include <type_traits>
 #include "common.hpp"
 
 namespace Sophus {
@@ -210,6 +211,14 @@ template <class Scalar_, int M, int N>
 struct GetScalar<Matrix<Scalar_, M, N>> {
   using Scalar = Scalar_;
 };
+
+// If the Vector type is a fixed size, then IsFixedSizeVector::value will be
+// true.
+template <typename Vector, int NumDimensions,
+          typename = typename std::enable_if<
+              Vector::RowsAtCompileTime == NumDimensions &&
+              Vector::ColsAtCompileTime == 1>::type>
+struct IsFixedSizeVector : std::true_type {};
 
 // Planes in 3d are hyperplanes.
 template <class T>

--- a/test/ceres/test_ceres_se3.cpp
+++ b/test/ceres/test_ceres_se3.cpp
@@ -27,25 +27,68 @@ struct cast_impl<ceres::Jet<T, N>, NewType> {
 }  // namespace internal
 }  // namespace Eigen
 
-struct TestCostFunctor {
+struct TestSE3CostFunctor {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  TestCostFunctor(Sophus::SE3d T_aw) : T_aw(T_aw) {}
+  TestSE3CostFunctor(Sophus::SE3d T_aw) : T_aw(T_aw) {}
 
   template <class T>
   bool operator()(T const* const sT_wa, T* sResiduals) const {
     Eigen::Map<Sophus::SE3<T> const> const T_wa(sT_wa);
     Eigen::Map<Eigen::Matrix<T, 6, 1> > residuals(sResiduals);
 
-    residuals = (T_aw.cast<T>() * T_wa).log();
+    // We are able to mix Sophus types with doubles and Jet types withou needing
+    // to cast to T.
+    residuals = (T_aw * T_wa).log();
+    // Reverse order of multiplication. This forces the compiler to verify that
+    // (Jet, double) and (double, Jet) SE3 multiplication work correctly.
+    residuals = (T_wa * T_aw).log();
+    // Finally, ensure that Jet-to-Jet multiplication works.
+    residuals = (T_wa * T_aw.cast<T>()).log();
     return true;
   }
 
   Sophus::SE3d T_aw;
 };
 
-bool test(Sophus::SE3d const& T_w_targ, Sophus::SE3d const& T_w_init) {
-  // Optimisation parameter
+struct TestPointCostFunctor {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  TestPointCostFunctor(Sophus::SE3d T_aw, Eigen::Vector3d point_a)
+      : T_aw(T_aw), point_a(point_a) {}
+
+  template <class T>
+  bool operator()(T const* const sT_wa, T const* const spoint_b,
+                  T* sResiduals) const {
+    using Vector3T = Eigen::Matrix<T, 3, 1>;
+    Eigen::Map<Sophus::SE3<T> const> const T_wa(sT_wa);
+    Eigen::Map<Vector3T const> point_b(spoint_b);
+    Eigen::Map<Vector3T> residuals(sResiduals);
+
+    // Multiply SE3d by Jet Vector3.
+    Vector3T point_b_prime = T_aw * point_b;
+    // Ensure Jet SE3 multiplication with Jet Vector3.
+    point_b_prime = T_aw.cast<T>() * point_b;
+
+    // Multiply Jet SE3 with Vector3d.
+    Vector3T point_a_prime = T_wa * point_a;
+    // Ensure Jet SE3 multiplication with Jet Vector3.
+    point_a_prime = T_wa * point_a.cast<T>();
+
+    residuals = point_b_prime - point_a_prime;
+    return true;
+  }
+
+  Sophus::SE3d T_aw;
+  Eigen::Vector3d point_a;
+};
+
+bool test(Sophus::SE3d const& T_w_targ, Sophus::SE3d const& T_w_init,
+          Sophus::SE3d::Point const& point_a_init,
+          Sophus::SE3d::Point const& point_b) {
+  static constexpr int kNumPointParameters = 3;
+
+  // Optimisation parameters.
   Sophus::SE3d T_wr = T_w_init;
+  Sophus::SE3d::Point point_a = point_a_init;
 
   // Build the problem.
   ceres::Problem problem;
@@ -54,14 +97,19 @@ bool test(Sophus::SE3d const& T_w_targ, Sophus::SE3d const& T_w_init) {
   problem.AddParameterBlock(T_wr.data(), Sophus::SE3d::num_parameters,
                             new Sophus::test::LocalParameterizationSE3);
 
-  // Create and add cost function. Derivatives will be evaluated via
+  // Create and add cost functions. Derivatives will be evaluated via
   // automatic differentiation
-
-  TestCostFunctor* c = new TestCostFunctor(T_w_targ.inverse());
-  ceres::CostFunction* cost_function =
-      new ceres::AutoDiffCostFunction<TestCostFunctor, Sophus::SE3d::DoF,
-                                      Sophus::SE3d::num_parameters>(c);
-  problem.AddResidualBlock(cost_function, NULL, T_wr.data());
+  ceres::CostFunction* cost_function1 =
+      new ceres::AutoDiffCostFunction<TestSE3CostFunctor, Sophus::SE3d::DoF,
+                                      Sophus::SE3d::num_parameters>(
+          new TestSE3CostFunctor(T_w_targ.inverse()));
+  problem.AddResidualBlock(cost_function1, NULL, T_wr.data());
+  ceres::CostFunction* cost_function2 =
+      new ceres::AutoDiffCostFunction<TestPointCostFunctor, kNumPointParameters,
+                                      Sophus::SE3d::num_parameters,
+                                      kNumPointParameters>(
+          new TestPointCostFunctor(T_w_targ.inverse(), point_b));
+  problem.AddResidualBlock(cost_function2, NULL, T_wr.data(), point_a.data());
 
   // Set solver options (precision / method)
   ceres::Solver::Options options;
@@ -115,8 +163,21 @@ int main(int, char**) {
       SE3Type(SO3Type::exp(Point(kPi, 0, 0)), Point(0, 0, 0)) *
       SE3Type(SO3Type::exp(Point(-0.3, -0.5, -0.1)), Point(0, 6, 0)));
 
+  std::vector<Point> point_vec;
+  point_vec.emplace_back(1.012, 2.73, -1.4);
+  point_vec.emplace_back(9.2, -7.3, -4.4);
+  point_vec.emplace_back(2.5, 0.1, 9.1);
+  point_vec.emplace_back(12.3, 1.9, 3.8);
+  point_vec.emplace_back(-3.21, 3.42, 2.3);
+  point_vec.emplace_back(-8.0, 6.1, -1.1);
+  point_vec.emplace_back(0.0, 2.5, 5.9);
+  point_vec.emplace_back(7.1, 7.8, -14);
+  point_vec.emplace_back(5.8, 9.2, 0.0);
+
   for (size_t i = 0; i < se3_vec.size(); ++i) {
-    bool const passed = test(se3_vec[i], se3_vec[(i + 3) % se3_vec.size()]);
+    const int other_index = (i + 3) % se3_vec.size();
+    bool const passed = test(se3_vec[i], se3_vec[other_index], point_vec[i],
+                             point_vec[other_index]);
     if (!passed) {
       std::cerr << "failed!" << std::endl << std::endl;
       exit(-1);

--- a/test/core/tests.hpp
+++ b/test/core/tests.hpp
@@ -25,6 +25,7 @@ class LieGroupTests {
   using Transformation = typename LieGroup::Transformation;
   using Tangent = typename LieGroup::Tangent;
   using Point = typename LieGroup::Point;
+  using HomogeneousPoint = typename LieGroup::HomogeneousPoint;
   using ConstPointMap = Eigen::Map<const Point>;
   using Line = typename LieGroup::Line;
   using Adjoint = typename LieGroup::Adjoint;
@@ -221,14 +222,22 @@ class LieGroupTests {
     for (size_t i = 0; i < group_vec_.size(); ++i) {
       for (size_t j = 0; j < point_vec_.size(); ++j) {
         Point const& p = point_vec_[j];
-        ConstPointMap p_map(p.data());
-        Transformation T = group_vec_[i].matrix();
         Point point1 = group_vec_[i] * p;
-        Point point2 = group_vec_[i] * p_map;
-        Point point3 = map(T, p);
-        SOPHUS_TEST_APPROX(passed, point1, point3, kSmallEps,
+
+        HomogeneousPoint hp = p.homogeneous();
+        HomogeneousPoint hpoint1 = group_vec_[i] * hp;
+
+        ConstPointMap p_map(p.data());
+        Point pointmap1 = group_vec_[i] * p_map;
+
+        Transformation T = group_vec_[i].matrix();
+        Point gt_point1 = map(T, p);
+
+        SOPHUS_TEST_APPROX(passed, point1, gt_point1, kSmallEps,
                            "Transform point case: %", i);
-        SOPHUS_TEST_APPROX(passed, point2, point3, kSmallEps,
+        SOPHUS_TEST_APPROX(passed, hpoint1.hnormalized().eval(), gt_point1,
+                           kSmallEps, "Transform homogeneous point case: %", i);
+        SOPHUS_TEST_APPROX(passed, pointmap1, gt_point1, kSmallEps,
                            "Transform map point case: %", i);
       }
     }

--- a/test/core/tests.hpp
+++ b/test/core/tests.hpp
@@ -25,6 +25,7 @@ class LieGroupTests {
   using Transformation = typename LieGroup::Transformation;
   using Tangent = typename LieGroup::Tangent;
   using Point = typename LieGroup::Point;
+  using ConstPointMap = Eigen::Map<const Point>;
   using Line = typename LieGroup::Line;
   using Adjoint = typename LieGroup::Adjoint;
   static int constexpr N = LieGroup::N;
@@ -220,11 +221,15 @@ class LieGroupTests {
     for (size_t i = 0; i < group_vec_.size(); ++i) {
       for (size_t j = 0; j < point_vec_.size(); ++j) {
         Point const& p = point_vec_[j];
+        ConstPointMap p_map(p.data());
         Transformation T = group_vec_[i].matrix();
         Point point1 = group_vec_[i] * p;
-        Point point2 = map(T, p);
-        SOPHUS_TEST_APPROX(passed, point1, point2, kSmallEps,
+        Point point2 = group_vec_[i] * p_map;
+        Point point3 = map(T, p);
+        SOPHUS_TEST_APPROX(passed, point1, point3, kSmallEps,
                            "Transform point case: %", i);
+        SOPHUS_TEST_APPROX(passed, point2, point3, kSmallEps,
+                           "Transform map point case: %", i);
       }
     }
     return passed;


### PR DESCRIPTION
This PR enhances the operator* for Sophus types in several ways:

1. Allowing product with different derived classes. This allows e.g., SE3Base to multiply with any SE3Base such as Eigen::Map<SE3d>. Previously the operator* required both objects to be the same type, limiting the ability to use concrete objects with maps. This same change was also made for Point multiplication operators.

2. Enable mixing double and ceres::Jet scalars for Sophus object multiplication. ceres::Jet-to-double operations are generally faster than Jet-to-Jet, so the change from 1. also allows multiplying Sophus objects when one object is a ceres::Jet type and the other is a double.

3. Add new operator for Homogeneous Point multiplication. Homogeneous points are a convenient representation for points near infinity which cannot be easily represented by a standard point, and have a straightforward multiplication operator for Sophus objects.

4. Updated unit tests to test Homogeneous Points.

5. Updated ceres unit test to force compilation of mixing doubles and Jets for operator* without needing .cast<T>(). Also demonstrate the ability for Sophus to multiply a concrete object with a Eigen::Map object.