### PR TITLE
Fix in-place multiplication for product operator.

### DIFF
--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -229,9 +229,8 @@ class SE2Base {
   template <typename OtherDerived>
   SOPHUS_FUNC SE2Product<OtherDerived> operator*(
       SE2Base<OtherDerived> const& other) const {
-    SE2Product<OtherDerived> result(*this);
-    result *= other;
-    return result;
+    return SE2Product<OtherDerived>(
+        so2() * other.so2(), translation() + so2() * other.translation());
   }
 
   // Group action on 2-points.
@@ -281,8 +280,7 @@ class SE2Base {
             typename = typename std::enable_if<
                 std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
   SOPHUS_FUNC SE2Base<Derived>& operator*=(SE2Base<OtherDerived> const& other) {
-    translation() += so2() * (other.translation());
-    so2() *= other.so2();
+    *static_cast<Derived*>(this) = *this * other;
     return *this;
   }
 
@@ -677,6 +675,10 @@ class SE2 : public SE2Base<SE2<Scalar_, Options>> {
   template <class T0, class T1>
   static SOPHUS_FUNC SE2 trans(T0 const& x, T1 const& y) {
     return SE2(SO2<Scalar>(), Vector2<Scalar>(x, y));
+  }
+
+  static SOPHUS_FUNC SE2 trans(Vector2<Scalar> const& xy) {
+    return SE2(SO2<Scalar>(), xy);
   }
 
   // Contruct x-axis translation.

--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -349,14 +349,14 @@ class SE3Base {
   }
 
   // In-place group multiplication. This method is only valid if the return type
-  // of the multiplication is compatible with this SO2's Scalar type.
+  // of the multiplication is compatible with this SE3's Scalar type.
   //
   template <typename OtherDerived,
             typename = typename std::enable_if<
                 std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
   SOPHUS_FUNC SE3Base<Derived>& operator*=(SE3Base<OtherDerived> const& other) {
-    *this = *this * other;
-    return this;
+    *static_cast<Derived*>(this) = *this * other;
+    return *this;
   }
 
   // Returns rotation matrix.
@@ -915,6 +915,10 @@ class SE3 : public SE3Base<SE3<Scalar_, Options>> {
   template <class T0, class T1, class T2>
   static SOPHUS_FUNC SE3 trans(T0 const& x, T1 const& y, T2 const& z) {
     return SE3(SO3<Scalar>(), Vector3<Scalar>(x, y, z));
+  }
+
+  static SOPHUS_FUNC SE3 trans(Vector3<Scalar> const& xyz) {
+    return SE3(SO3<Scalar>(), xyz);
   }
 
   // Construct x-axis translation.

--- a/sophus/sim2.hpp
+++ b/sophus/sim2.hpp
@@ -208,9 +208,8 @@ class Sim2Base {
   template <typename OtherDerived>
   SOPHUS_FUNC Sim2Product<OtherDerived> operator*(
       Sim2Base<OtherDerived> const& other) const {
-    Sim2Product<OtherDerived> result(*this);
-    result *= other;
-    return result;
+    return Sim2Product<OtherDerived>(
+        rxso2() * other.rxso2(), translation() + rxso2() * other.translation());
   }
 
   // Group action on 2-points.
@@ -273,8 +272,7 @@ class Sim2Base {
                 std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
   SOPHUS_FUNC Sim2Base<Derived>& operator*=(
       Sim2Base<OtherDerived> const& other) {
-    translation() += (rxso2() * other.translation());
-    rxso2() *= other.rxso2();
+    *static_cast<Derived*>(this) = *this * other;
     return *this;
   }
 

--- a/sophus/sim3.hpp
+++ b/sophus/sim3.hpp
@@ -210,9 +210,8 @@ class Sim3Base {
   template <typename OtherDerived>
   SOPHUS_FUNC Sim3Product<OtherDerived> operator*(
       Sim3Base<OtherDerived> const& other) const {
-    Sim3Product<OtherDerived> result(*this);
-    result *= other;
-    return result;
+    return Sim3Product<OtherDerived>(
+        rxso3() * other.rxso3(), translation() + rxso3() * other.translation());
   }
 
   // Group action on 3-points.
@@ -264,8 +263,7 @@ class Sim3Base {
                 std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
   SOPHUS_FUNC Sim3Base<Derived>& operator*=(
       Sim3Base<OtherDerived> const& other) {
-    translation() += (rxso3() * other.translation());
-    rxso3() *= other.rxso3();
+    *static_cast<Derived*>(this) = *this * other;
     return *this;
   }
 

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -390,7 +390,7 @@ class SO3Base {
             typename = typename std::enable_if<
                 std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
   SOPHUS_FUNC SO3Base<Derived>& operator*=(SO3Base<OtherDerived> const& other) {
-    *this = *this * other;
+    *static_cast<Derived*>(this) = *this * other;
     return *this;
   }
 

--- a/test/core/tests.hpp
+++ b/test/core/tests.hpp
@@ -192,6 +192,19 @@ class LieGroupTests {
     return true;
   }
 
+  bool productTest() {
+    bool passed = true;
+
+    for (size_t i = 0; i < group_vec_.size() - 1; ++i) {
+      LieGroup T1 = group_vec_[i];
+      LieGroup T2 = group_vec_[i + 1];
+      LieGroup mult = T1 * T2;
+      T1 *= T2;
+      SOPHUS_TEST_APPROX(passed, T1.matrix(), mult.matrix(), kSmallEps, "Product case: %", i);
+    }
+    return passed;
+  }
+
   bool expLogTest() {
     bool passed = true;
 
@@ -449,6 +462,7 @@ class LieGroupTests {
     bool passed = true;
     passed &= adjointTest();
     passed &= contructorAndAssignmentTest();
+    passed &= productTest();
     passed &= expLogTest();
     passed &= groupActionTest();
     passed &= lineActionTest();


### PR DESCRIPTION
This makes the functionality consistent with all Sophus types such
that the binary product operator is used for all in-place
products. This also fixes the storage issue by casting (this) to
the Derived type upon assignment.