### PR TITLE
Fix setRotationMatrix methods in SE2 and SE3

### DIFF
--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -315,10 +315,11 @@ class SE2Base {
   //
   SOPHUS_FUNC void setRotationMatrix(Matrix<Scalar, 2, 2> const& R) {
     SOPHUS_ENSURE(isOrthogonal(R), "R is not orthogonal:\n %", R);
-    SOPHUS_ENSURE(R.determinant() > 0, "det(R) is not positive: %",
+    SOPHUS_ENSURE(R.determinant() > Scalar(0), "det(R) is not positive: %",
                   R.determinant());
-    so2().setComplex(Scalar(0.5) * (R(0, 0) + R(1, 1)),
-                     Scalar(0.5) * (R(1, 0) - R(0, 1)));
+    typename SO2Type::ComplexT const complex(Scalar(0.5) * (R(0, 0) + R(1, 1)),
+                                             Scalar(0.5) * (R(1, 0) - R(0, 1)));
+    so2().setComplex(complex);
   }
 
   // Mutator of SO3 group.

--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -387,7 +387,7 @@ class SE3Base {
   //
   SOPHUS_FUNC void setRotationMatrix(Matrix3<Scalar> const& R) {
     SOPHUS_ENSURE(isOrthogonal(R), "R is not orthogonal:\n %", R);
-    SOPHUS_ENSURE(R.determinant() > 0, "det(R) is not positive: %",
+    SOPHUS_ENSURE(R.determinant() > Scalar(0), "det(R) is not positive: %",
                   R.determinant());
     so3().setQuaternion(Eigen::Quaternion<Scalar>(R));
   }

--- a/test/core/test_se2.cpp
+++ b/test/core/test_se2.cpp
@@ -70,6 +70,7 @@ class Tests {
   void runAll() {
     bool passed = testLieProperties();
     passed &= testRawDataAcces();
+    passed &= testMutatingAccessors();
     passed &= testConstructors();
     passed &= testFit();
     processTestResult(passed);
@@ -147,6 +148,18 @@ class Tests {
     trans = SE2Type::transY(Scalar(0.7));
     SOPHUS_TEST_APPROX(passed, trans.translation().y(), Scalar(0.7),
                        Constants<Scalar>::epsilon());
+
+    return passed;
+  }
+
+  bool testMutatingAccessors() {
+    bool passed = true;
+    SE2Type se2;
+    SO2Type R(Scalar(0.2));
+    se2.setRotationMatrix(R.matrix());
+    SOPHUS_TEST_APPROX(passed, se2.rotationMatrix(), R.matrix(),
+                       Constants<Scalar>::epsilon());
+
     return passed;
   }
 

--- a/test/core/test_se3.cpp
+++ b/test/core/test_se3.cpp
@@ -53,6 +53,7 @@ class Tests {
   void runAll() {
     bool passed = testLieProperties();
     passed &= testRawDataAcces();
+    passed &= testMutatingAccessors();
     passed &= testConstructors();
     passed &= testFit();
     processTestResult(passed);
@@ -150,6 +151,17 @@ class Tests {
     t << Scalar(0), Scalar(0), Scalar(0), Scalar(0), Scalar(0), Scalar(1.1);
     SOPHUS_TEST_EQUAL(passed, SE3Type::rotZ(Scalar(1.1)).matrix(),
                       SE3Type::exp(t).matrix());
+
+    return passed;
+  }
+
+  bool testMutatingAccessors() {
+    bool passed = true;
+    SE3Type se3;
+    SO3Type R(SO3Type::exp(Point(Scalar(0.2), Scalar(0.5), Scalar(0.0))));
+    se3.setRotationMatrix(R.matrix());
+    SOPHUS_TEST_APPROX(passed, se3.rotationMatrix(), R.matrix(),
+                       Constants<Scalar>::epsilon());
 
     return passed;
   }


### PR DESCRIPTION
Previously `SE2<T>::setRotationMatrix(...)` did not compile for any type and
`SE3<T>::setRotationMatrix(...)` did not compile for Ceres Jet types.

This commit also adds tests for both setRotationMatrix methods.