### PR TITLE
Add generic ceres::LocalParameterization to all groups from Sophus

### DIFF
--- a/run_format.sh
+++ b/run_format.sh
@@ -1,1 +1,1 @@
-find . -iname *.hpp -o -iname *.cpp | xargs clang-format -i
+find . -iname *.hpp -o -iname *.cpp | xargs clang-format -style=file -i

--- a/sophus/average.hpp
+++ b/sophus/average.hpp
@@ -63,7 +63,7 @@ average(SequenceContainer const& foo_Ts_bar) {
 
   Scalar average(0);
   for (SO2<Scalar> const& foo_T_bar : foo_Ts_bar) {
-    average += w * (foo_T_average.inverse() * foo_T_bar).log();
+    average += w * (foo_T_average.inverse() * foo_T_bar).log()[0];
   }
   return foo_T_average * SO2<Scalar>::exp(average);
 }

--- a/sophus/ceres_local_parameterization.hpp
+++ b/sophus/ceres_local_parameterization.hpp
@@ -1,0 +1,49 @@
+#ifndef SOPHUS_CERES_LOCAL_PARAMETERIZATION_HPP
+#define SOPHUS_CERES_LOCAL_PARAMETERIZATION_HPP
+
+namespace Sophus {
+
+template <template <typename, int = 0> class LieGroup>
+class LocalParameterization : public ceres::LocalParameterization {
+ public:
+  using LieGroupd = LieGroup<double>;
+  using Tangent = typename LieGroupd::Tangent;
+  static int constexpr DoF = LieGroupd::DoF;
+  static int constexpr num_parameters = LieGroupd::num_parameters;
+  virtual ~LocalParameterization() {}
+
+  // LieGroup plus operation for Ceres
+  //
+  //  T * exp(x)
+  //
+  virtual bool Plus(double const* T_raw, double const* delta_raw,
+                    double* T_plus_delta_raw) const {
+    Eigen::Map<LieGroupd const> const T(T_raw);
+    Eigen::Map<Tangent const> const delta(delta_raw);
+    Eigen::Map<LieGroupd> T_plus_delta(T_plus_delta_raw);
+    T_plus_delta = T * LieGroupd::exp(delta);
+    return true;
+  }
+
+  // Jacobian of LieGroup plus operation for Ceres
+  //
+  // Dx T * exp(x)  with  x=0
+  //
+  virtual bool ComputeJacobian(double const* T_raw,
+                               double* jacobian_raw) const {
+    Eigen::Map<LieGroupd const> T(T_raw);
+    Eigen::Map<Eigen::Matrix<double, num_parameters, DoF,
+                             DoF == 1 ? Eigen::ColMajor : Eigen::RowMajor>>
+        jacobian(jacobian_raw);
+    jacobian = T.Dx_this_mul_exp_x_at_0();
+    return true;
+  }
+
+  virtual int GlobalSize() const { return LieGroupd::num_parameters; }
+
+  virtual int LocalSize() const { return LieGroupd::DoF; }
+};
+
+}  // namespace Sophus
+
+#endif

--- a/sophus/interpolate_details.hpp
+++ b/sophus/interpolate_details.hpp
@@ -22,7 +22,7 @@ struct Traits<SO2<Scalar>> {
 
   static bool hasShortestPathAmbiguity(SO2<Scalar> const& foo_T_bar) {
     using std::abs;
-    Scalar angle = foo_T_bar.log();
+    Scalar angle = foo_T_bar.log()[0];
     return abs(abs(angle) - Constants<Scalar>::pi()) <
            Constants<Scalar>::epsilon();
   }
@@ -98,7 +98,7 @@ struct Traits<Sim3<Scalar>> {
   }
 };
 
-}  // namespace details
+}  // namespace interp_details
 }  // namespace Sophus
 
 #endif  // SOPHUS_INTERPOLATE_DETAILS_HPP

--- a/sophus/num_diff.hpp
+++ b/sophus/num_diff.hpp
@@ -51,7 +51,7 @@ class VectorField {
 };
 
 template <class Scalar, int N>
-class VectorField<Scalar, N, 1> {
+class ScalarField {
  public:
   static Eigen::Matrix<Scalar, N, 1> num_diff(
       std::function<Sophus::Vector<Scalar, N>(Scalar)> vector_field,

--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -157,7 +157,7 @@ class SE2Base {
     using std::abs;
 
     Tangent upsilon_theta;
-    Scalar theta = so2().log();
+    Scalar theta = so2().log()[0];
     upsilon_theta[2] = theta;
     Scalar halftheta = Scalar(0.5) * theta;
     Scalar halftheta_by_tan_of_halftheta;
@@ -417,6 +417,9 @@ class SE2 : public SE2Base<SE2<Scalar_, Options>> {
   // Constructor from rotation angle and translation vector.
   //
   SOPHUS_FUNC SE2(Scalar const& theta, Point const& translation)
+      : so2_(theta), translation_(translation) {}
+  SOPHUS_FUNC SE2(typename Base::SO2Type::Tangent const& theta,
+                  Point const& translation)
       : so2_(theta), translation_(translation) {}
 
   // Constructor from complex number and translation vector
@@ -712,7 +715,8 @@ class SE2 : public SE2Base<SE2<Scalar_, Options>> {
         "Omega: \n%", Omega);
     Tangent upsilon_omega;
     upsilon_omega.template head<2>() = Omega.col(2).template head<2>();
-    upsilon_omega[2] = SO2<Scalar>::vee(Omega.template topLeftCorner<2, 2>());
+    upsilon_omega[2] =
+        SO2<Scalar>::vee(Omega.template topLeftCorner<2, 2>())[0];
     return upsilon_omega;
   }
 

--- a/sophus/sim3.hpp
+++ b/sophus/sim3.hpp
@@ -267,6 +267,19 @@ class Sim3Base {
     return *this;
   }
 
+  // Returns derivative of  this * Sim3::exp(x) w.r.t. x at x = 0
+  //
+  SOPHUS_FUNC Matrix<Scalar, num_parameters, DoF> Dx_this_mul_exp_x_at_0()
+      const {
+    Matrix<Scalar, num_parameters, DoF> J;
+    J.template block<4, 3>(0, 0).setZero();
+    J.template block<4, 4>(0, 3) = rxso3().Dx_this_mul_exp_x_at_0();
+    J.template block<3, 3>(4, 0) = rxso3().matrix();
+    J.template block<3, 4>(4, 3).setZero();
+
+    return J;
+  }
+
   // Returns internal parameters of Sim(3).
   //
   // It returns (q.imag[0], q.imag[1], q.imag[2], q.real, t[0], t[1], t[2]),
@@ -359,6 +372,9 @@ class Sim3 : public Sim3Base<Sim3<Scalar_, Options>> {
   using Base = Sim3Base<Sim3<Scalar_, Options>>;
 
  public:
+  static int constexpr DoF = Base::DoF;
+  static int constexpr num_parameters = Base::num_parameters;
+
   using Scalar = Scalar_;
   using Transformation = typename Base::Transformation;
   using Point = typename Base::Point;
@@ -491,6 +507,73 @@ class Sim3 : public Sim3Base<Sim3<Scalar_, Options>> {
 
     Matrix3<Scalar> const W = details::calcW<Scalar, 3>(Omega, theta, sigma);
     return Sim3<Scalar>(rxso3, W * upsilon);
+  }
+
+  // Returns derivative of exp(x) wrt. x_i at x=0.
+  //
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF>
+  Dx_exp_x_at_0() {
+    Sophus::Matrix<Scalar, num_parameters, DoF> J;
+    J.template block<4, 3>(0, 0).setZero();
+    J.template block<4, 4>(0, 3) = RxSO3<Scalar>::Dx_exp_x_at_0();
+    J.template block<3, 3>(4, 0).setIdentity();
+    J.template block<3, 4>(4, 3).setZero();
+    return J;
+  }
+
+  // Returns derivative of exp(x) wrt. x.
+  //
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF> Dx_exp_x(
+      const Tangent& a) {
+    Sophus::Matrix<Scalar, num_parameters, DoF> J;
+
+    static Matrix3<Scalar> const I = Matrix3<Scalar>::Identity();
+    Vector3<Scalar> const omega = a.template segment<3>(3);
+    Vector3<Scalar> const upsilon = a.template head<3>();
+    Scalar const sigma = a[6];
+    Scalar const theta = omega.norm();
+
+    Matrix3<Scalar> const Omega = SO3<Scalar>::hat(omega);
+    Matrix3<Scalar> const Omega2 = Omega * Omega;
+    Vector3<Scalar> theta_domega;
+    if (theta < Constants<Scalar>::epsilon()) {
+      theta_domega = Vector3<Scalar>::Zero();
+    } else {
+      theta_domega = omega / theta;
+    }
+    static Matrix3<Scalar> const Omega_domega[3] = {
+        SO3<Scalar>::hat(Vector3<Scalar>::Unit(0)),
+        SO3<Scalar>::hat(Vector3<Scalar>::Unit(1)),
+        SO3<Scalar>::hat(Vector3<Scalar>::Unit(2))};
+
+    Matrix3<Scalar> const Omega2_domega[3] = {
+        Omega_domega[0] * Omega + Omega * Omega_domega[0],
+        Omega_domega[1] * Omega + Omega * Omega_domega[1],
+        Omega_domega[2] * Omega + Omega * Omega_domega[2]};
+
+    Matrix3<Scalar> const W = details::calcW<Scalar, 3>(Omega, theta, sigma);
+
+    J.template block<4, 3>(0, 0).setZero();
+    J.template block<4, 4>(0, 3) =
+        RxSO3<Scalar>::Dx_exp_x(a.template tail<4>());
+    J.template block<3, 4>(4, 3).setZero();
+    J.template block<3, 3>(4, 0) = W;
+
+    Scalar A, B, C, A_dtheta, B_dtheta, A_dsigma, B_dsigma, C_dsigma;
+    details::calcW_derivatives(theta, sigma, A, B, C, A_dsigma, B_dsigma,
+                               C_dsigma, A_dtheta, B_dtheta);
+
+    for (int i = 0; i < 3; ++i) {
+      J.template block<3, 1>(4, 3 + i) =
+          (A_dtheta * theta_domega[i] * Omega + A * Omega_domega[i] +
+           B_dtheta * theta_domega[i] * Omega2 + B * Omega2_domega[i]) *
+          upsilon;
+    }
+
+    J.template block<3, 1>(4, 6) =
+        (A_dsigma * Omega + B_dsigma * Omega2 + C_dsigma * I) * upsilon;
+
+    return J;
   }
 
   // Returns the ith infinitesimal generators of Sim(3).

--- a/sophus/sim_details.hpp
+++ b/sophus/sim_details.hpp
@@ -7,12 +7,12 @@ namespace Sophus {
 namespace details {
 
 template <class Scalar, int N>
-Matrix<Scalar, N, N> calcW(Matrix<Scalar, N, N> const& Omega,
+Matrix<Scalar, N, N> calcW(Matrix<Scalar, N, N> const &Omega,
                            Scalar const theta, Scalar const sigma) {
   using std::abs;
+  using std::cos;
   using std::exp;
   using std::sin;
-  using std::cos;
   static Matrix<Scalar, N, N> const I = Matrix<Scalar, N, N>::Identity();
   static Scalar const one(1);
   static Scalar const half(0.5);
@@ -48,13 +48,104 @@ Matrix<Scalar, N, N> calcW(Matrix<Scalar, N, N> const& Omega,
   return A * Omega + B * Omega2 + C * I;
 }
 
+template <class Scalar>
+void calcW_derivatives(Scalar const theta, Scalar const sigma, Scalar &A,
+                       Scalar &B, Scalar &C, Scalar &A_dsigma, Scalar &B_dsigma,
+                       Scalar &C_dsigma, Scalar &A_dtheta, Scalar &B_dtheta) {
+  using std::abs;
+  using std::cos;
+  using std::exp;
+  using std::sin;
+  static Scalar const zero(0.0);
+  static Scalar const one(1.0);
+  static Scalar const half(0.5);
+  static Scalar const two(2.0);
+  static Scalar const three(3.0);
+  Scalar const theta_sq = theta * theta;
+  Scalar const theta_c = theta * theta_sq;
+  Scalar const sin_theta = sin(theta);
+  Scalar const cos_theta = cos(theta);
+
+  Scalar const scale = exp(sigma);
+  Scalar const sigma_sq = sigma * sigma;
+  Scalar const sigma_c = sigma * sigma_sq;
+
+  if (abs(sigma) < Constants<Scalar>::epsilon()) {
+    C = one;
+    C_dsigma = half;
+    if (abs(theta) < Constants<Scalar>::epsilon()) {
+      A = half;
+      B = Scalar(1. / 6.);
+      A_dtheta = A_dsigma = zero;
+      B_dtheta = B_dsigma = zero;
+    } else {
+      A = (one - cos_theta) / theta_sq;
+      B = (theta - sin_theta) / theta_c;
+      A_dtheta = (theta * sin_theta + two * cos_theta - two) / theta_c;
+      B_dtheta = -(two * theta - three * sin_theta + theta * cos_theta) /
+                 (theta_c * theta);
+      A_dsigma = (sin_theta - theta * cos_theta) / theta_c;
+      B_dsigma =
+          (half - (cos_theta + theta * sin_theta - one) / theta_sq) / theta_sq;
+    }
+  } else {
+    C = (scale - one) / sigma;
+    C_dsigma = (scale * (sigma - one) + one) / sigma_sq;
+    if (abs(theta) < Constants<Scalar>::epsilon()) {
+      A = ((sigma - one) * scale + one) / sigma_sq;
+      B = (scale * half * sigma_sq + scale - one - sigma * scale) / sigma_c;
+      A_dsigma = (scale * (sigma_sq - two * sigma + two) - two) / sigma_c;
+      B_dsigma = (scale * (half * sigma_c - (one + half) * sigma_sq +
+                           three * sigma - three) +
+                  three) /
+                 (sigma_c * sigma);
+      A_dtheta = B_dtheta = zero;
+    } else {
+      Scalar const a = scale * sin_theta;
+      Scalar const b = scale * cos_theta;
+      Scalar const b_one = b - one;
+      Scalar const theta_b_one = theta * b_one;
+      Scalar const c = theta_sq + sigma_sq;
+      Scalar const c_sq = c * c;
+      Scalar const theta_sq_c = theta_sq * c;
+      Scalar const a_theta = theta * a;
+      Scalar const b_theta = theta * b;
+      Scalar const c_theta = theta * c;
+      Scalar const a_sigma = sigma * a;
+      Scalar const b_sigma = sigma * b;
+      Scalar const two_sigma = sigma * two;
+      Scalar const two_theta = theta * two;
+      Scalar const sigma_b_one = sigma * b_one;
+
+      A = (a_sigma - theta_b_one) / c_theta;
+      A_dtheta = (two * (theta_b_one - a_sigma)) / c_sq +
+                 (b_sigma - b + a_theta + one) / c_theta +
+                 (theta_b_one - a_sigma) / theta_sq_c;
+      A_dsigma = (a - b_theta + a_sigma) / c_theta -
+                 (two_sigma * (theta - b_theta + a_sigma)) / (theta * c_sq);
+
+      B = (C - (sigma_b_one + a_theta) / (c)) * one / (theta_sq);
+      B_dtheta =
+          ((two_theta * (b_sigma - sigma + a_theta)) / c_sq -
+           ((a + b_theta - a_sigma)) / c) /
+              theta_sq -
+          (two * ((scale - one) / sigma - (b_sigma - sigma + a_theta) / c)) /
+              theta_c;
+      B_dsigma =
+          -((b_sigma + a_theta + b_one) / c + (scale - one) / sigma_sq -
+            (two_sigma * (sigma_b_one + a_theta)) / c_sq - scale / sigma) /
+          theta_sq;
+    }
+  }
+}
+
 template <class Scalar, int N>
-Matrix<Scalar, N, N> calcWInv(Matrix<Scalar, N, N> const& Omega,
+Matrix<Scalar, N, N> calcWInv(Matrix<Scalar, N, N> const &Omega,
                               Scalar const theta, Scalar const sigma,
                               Scalar const scale) {
   using std::abs;
-  using std::sin;
   using std::cos;
+  using std::sin;
   static Matrix<Scalar, N, N> const I = Matrix<Scalar, N, N>::Identity();
   static Scalar const half(0.5);
   static Scalar const one(1);
@@ -97,7 +188,7 @@ Matrix<Scalar, N, N> calcWInv(Matrix<Scalar, N, N> const& Omega,
   return a * Omega + b * Omega2 + c * I;
 }
 
-}  // details
-}  // Sophus
+}  // namespace details
+}  // namespace Sophus
 
 #endif

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -87,7 +87,7 @@ class SO2Base {
   using Point = Vector2<Scalar>;
   using HomogeneousPoint = Vector3<Scalar>;
   using Line = ParametrizedLine2<Scalar>;
-  using Tangent = Scalar;
+  using Tangent = Vector1<Scalar>;
   using Adjoint = Scalar;
 
   // For binary operations the return type is determined with the
@@ -151,9 +151,11 @@ class SO2Base {
   // ``logmat(.)`` being the matrix logarithm and ``vee(.)`` the vee-operator
   // of SO(2).
   //
-  SOPHUS_FUNC Scalar log() const {
+  SOPHUS_FUNC Tangent log() const {
     using std::atan2;
-    return atan2(unit_complex().y(), unit_complex().x());
+    Tangent tangent;
+    tangent << atan2(unit_complex().y(), unit_complex().x());
+    return tangent;
   }
 
   // It re-normalizes ``unit_complex`` to unit length.
@@ -400,6 +402,9 @@ class SO2 : public SO2Base<SO2<Scalar_, Options>> {
   SOPHUS_FUNC explicit SO2(Scalar theta) {
     unit_complex_nonconst() = SO2<Scalar>::exp(theta).unit_complex();
   }
+  SOPHUS_FUNC explicit SO2(const Tangent& theta) {
+    unit_complex_nonconst() = SO2<Scalar>::exp(theta[0]).unit_complex();
+  }
 
   // Accessor of unit complex number
   //
@@ -416,19 +421,26 @@ class SO2 : public SO2Base<SO2<Scalar_, Options>> {
   // with ``expmat(.)`` being the matrix exponential and ``hat(.)`` being the
   // hat()-operator of SO(2).
   //
-  SOPHUS_FUNC static SO2<Scalar> exp(Tangent const& theta) {
+  SOPHUS_FUNC static SO2<Scalar> exp(Scalar const& theta) {
     using std::cos;
     using std::sin;
     return SO2<Scalar>(cos(theta), sin(theta));
+  }
+  SOPHUS_FUNC static SO2<Scalar> exp(Tangent const& theta) {
+    return exp(theta[0]);
   }
 
   // Returns derivative of exp(x) wrt. x.
   //
   SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF> Dx_exp_x(
-      Tangent const& theta) {
+      Scalar const& theta) {
     using std::cos;
     using std::sin;
     return Sophus::Matrix<Scalar, num_parameters, DoF>(-sin(theta), cos(theta));
+  }
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF> Dx_exp_x(
+      Tangent const& theta) {
+    return Dx_exp_x(theta[0]);
   }
 
   // Returns derivative of exp(x) wrt. x_i at x=0.
@@ -466,7 +478,7 @@ class SO2 : public SO2Base<SO2<Scalar_, Options>> {
   //
   // The corresponding inverse is the ``vee``-operator, see below.
   //
-  SOPHUS_FUNC static Transformation hat(Tangent const& theta) {
+  SOPHUS_FUNC static Transformation hat(Scalar const& theta) {
     Transformation Omega;
     // clang-format off
     Omega <<
@@ -474,6 +486,9 @@ class SO2 : public SO2Base<SO2<Scalar_, Options>> {
             theta, Scalar(0);
     // clang-format on
     return Omega;
+  }
+  SOPHUS_FUNC static Transformation hat(Tangent const& theta) {
+    return hat(theta[0]);
   }
 
   // Returns closed SO2 given arbirary 2x2 matrix.
@@ -490,7 +505,9 @@ class SO2 : public SO2Base<SO2<Scalar_, Options>> {
   // the Lie bracket is simple ``0``.
   //
   SOPHUS_FUNC static Tangent lieBracket(Tangent const&, Tangent const&) {
-    return Scalar(0);
+    Tangent tangent;
+    tangent << Scalar(0);
+    return tangent;
   }
 
   // Draw uniform sample from SO(2) manifold.
@@ -518,7 +535,9 @@ class SO2 : public SO2Base<SO2<Scalar_, Options>> {
   //
   SOPHUS_FUNC static Tangent vee(Transformation const& Omega) {
     using std::abs;
-    return Omega(1, 0);
+    Tangent tangent;
+    tangent << Omega(1, 0);
+    return tangent;
   }
 
  protected:

--- a/sophus/types.hpp
+++ b/sophus/types.hpp
@@ -10,6 +10,11 @@ template <class Scalar, int M, int Options = 0>
 using Vector = Eigen::Matrix<Scalar, M, 1, Options>;
 
 template <class Scalar, int Options = 0>
+using Vector1 = Vector<Scalar, 1, Options>;
+using Vector1f = Vector1<float>;
+using Vector1d = Vector1<double>;
+
+template <class Scalar, int Options = 0>
 using Vector2 = Vector<Scalar, 2, Options>;
 using Vector2f = Vector2<float>;
 using Vector2d = Vector2<double>;

--- a/test/ceres/CMakeLists.txt
+++ b/test/ceres/CMakeLists.txt
@@ -8,10 +8,10 @@ if( Ceres_FOUND )
   MESSAGE(STATUS "CERES found")
 
   # Tests to run
-  SET( TEST_SOURCES test_ceres_se3 )
+  SET( TEST_SOURCES test_ceres_se3 test_ceres_so3 test_ceres_sim3 test_ceres_rxso3 test_ceres_se2 test_ceres_so2 test_ceres_rxso2 test_ceres_sim2 )
 
   FOREACH(test_src ${TEST_SOURCES})
-    ADD_EXECUTABLE( ${test_src} ${test_src}.cpp local_parameterization_se3)
+    ADD_EXECUTABLE( ${test_src} ${test_src}.cpp)
     TARGET_LINK_LIBRARIES( ${test_src} sophus ${CERES_LIBRARIES} )
     TARGET_INCLUDE_DIRECTORIES( ${test_src} SYSTEM PRIVATE ${CERES_INCLUDE_DIRS})
     ADD_TEST( ${test_src} ${test_src} )

--- a/test/ceres/test_ceres_rxso2.cpp
+++ b/test/ceres/test_ceres_rxso2.cpp
@@ -1,0 +1,35 @@
+#include <ceres/ceres.h>
+#include <iostream>
+#include <sophus/rxso2.hpp>
+
+#include "tests.hpp"
+
+template <typename T>
+using StdVector = std::vector<T, Eigen::aligned_allocator<T>>;
+
+int main(int, char**) {
+  using RxSO2d = Sophus::RxSO2d;
+  using Tangent = RxSO2d::Tangent;
+  using Point = RxSO2d::Point;
+  double const kPi = Sophus::Constants<double>::pi();
+
+  StdVector<RxSO2d> so2_vec = {
+      RxSO2d::exp(Tangent(0.2, 1.)),
+      RxSO2d::exp(Tangent(0.2, 1.1)),
+      RxSO2d::exp(Tangent(0., 1.1)),
+      RxSO2d::exp(Tangent(0.00001, 0.)),
+      RxSO2d::exp(Tangent(0.00001, 0.00001)),
+      RxSO2d::exp(Tangent(kPi, 0.9)),
+      RxSO2d::exp(Tangent(0.2, 0)) * RxSO2d::exp(Tangent(kPi, 0.0)) *
+          RxSO2d::exp(Tangent(-0.2, 0)),
+      RxSO2d::exp(Tangent(0.3, 0)) * RxSO2d::exp(Tangent(kPi, 0.001)) *
+          RxSO2d::exp(Tangent(-0.3, 0))};
+
+  StdVector<Point> point_vec = {
+      Point(1.012, 2.73), Point(9.2, -7.3),   Point(2.5, 0.1),
+      Point(12.3, 1.9),   Point(-3.21, 3.42), Point(-8.0, 6.1),
+      Point(0.0, 2.5),    Point(7.1, 7.8),    Point(5.8, 9.2)};
+
+  Sophus::LieGroupCeresTests<Sophus::RxSO2>(so2_vec, point_vec).testAll();
+  return 0;
+}

--- a/test/ceres/test_ceres_rxso3.cpp
+++ b/test/ceres/test_ceres_rxso3.cpp
@@ -1,0 +1,40 @@
+#include <ceres/ceres.h>
+#include <iostream>
+#include <sophus/rxso3.hpp>
+
+#include "tests.hpp"
+
+template <typename T>
+using StdVector = std::vector<T, Eigen::aligned_allocator<T>>;
+
+int main(int, char**) {
+  using RxSO3d = Sophus::RxSO3d;
+  using Point = RxSO3d::Point;
+  using Tangent = RxSO3d::Tangent;
+  double const kPi = Sophus::Constants<double>::pi();
+
+  StdVector<RxSO3d> rxso3_vec = {RxSO3d::exp(Tangent(0.2, 0.5, 0.0, 1.)),
+                                 RxSO3d::exp(Tangent(0.2, 0.5, -1.0, 1.1)),
+                                 RxSO3d::exp(Tangent(0., 0., 0., 1.1)),
+                                 RxSO3d::exp(Tangent(0., 0., 0.00001, 0.)),
+                                 RxSO3d::exp(Tangent(0., 0., 0.00001, 0.00001)),
+                                 RxSO3d::exp(Tangent(0., 0., 0.00001, 0)),
+
+                                 RxSO3d::exp(Tangent(kPi, 0, 0, 0.9)),
+
+                                 RxSO3d::exp(Tangent(0.2, -0.5, 0, 0)) *
+                                     RxSO3d::exp(Tangent(kPi, 0, 0, 0)) *
+                                     RxSO3d::exp(Tangent(-0.2, -0.5, 0, 0)),
+
+                                 RxSO3d::exp(Tangent(0.3, 0.5, 0.1, 0)) *
+                                     RxSO3d::exp(Tangent(kPi, 0, 0, 0)) *
+                                     RxSO3d::exp(Tangent(-0.3, -0.5, -0.1, 0))};
+
+  StdVector<Point> point_vec = {
+      Point(1.012, 2.73, -1.4), Point(9.2, -7.3, -4.4),  Point(2.5, 0.1, 9.1),
+      Point(12.3, 1.9, 3.8),    Point(-3.21, 3.42, 2.3), Point(-8.0, 6.1, -1.1),
+      Point(0.0, 2.5, 5.9),     Point(7.1, 7.8, -14),    Point(5.8, 9.2, 0.0)};
+
+  Sophus::LieGroupCeresTests<Sophus::RxSO3>(rxso3_vec, point_vec).testAll();
+  return 0;
+}

--- a/test/ceres/test_ceres_se2.cpp
+++ b/test/ceres/test_ceres_se2.cpp
@@ -1,0 +1,34 @@
+#include <ceres/ceres.h>
+#include <iostream>
+#include <sophus/se2.hpp>
+
+#include "tests.hpp"
+
+template <typename T>
+using StdVector = std::vector<T, Eigen::aligned_allocator<T>>;
+
+int main(int, char**) {
+  using SE2d = Sophus::SE2d;
+  using SO2d = Sophus::SO2d;
+  using Point = SE2d::Point;
+  double const kPi = Sophus::Constants<double>::pi();
+
+  StdVector<SE2d> se2_vec = {
+      SE2d(SO2d(0.0), Point(0, 0)),
+      SE2d(SO2d(0.2), Point(10, 0)),
+      SE2d(SO2d(0.), Point(0, 100)),
+      SE2d(SO2d(-1.), Point(20, -1)),
+      SE2d(SO2d(0.00001), Point(-0.00000001, 0.0000000001)),
+      SE2d(SO2d(0.2), Point(0, 0)) * SE2d(SO2d(kPi), Point(0, 0)) *
+          SE2d(SO2d(-0.2), Point(0, 0)),
+      SE2d(SO2d(0.3), Point(2, 0)) * SE2d(SO2d(kPi), Point(0, 0)) *
+          SE2d(SO2d(-0.3), Point(0, 6))};
+
+  StdVector<Point> point_vec = {
+      Point(1.012, 2.73), Point(9.2, -7.3),   Point(2.5, 0.1),
+      Point(12.3, 1.9),   Point(-3.21, 3.42), Point(-8.0, 6.1),
+      Point(0.0, 2.5),    Point(7.1, 7.8),    Point(5.8, 9.2)};
+
+  Sophus::LieGroupCeresTests<Sophus::SE2>(se2_vec, point_vec).testAll();
+  return 0;
+}

--- a/test/ceres/test_ceres_se3.cpp
+++ b/test/ceres/test_ceres_se3.cpp
@@ -2,191 +2,39 @@
 #include <iostream>
 #include <sophus/se3.hpp>
 
-#include "local_parameterization_se3.hpp"
+#include "tests.hpp"
 
-// Eigen's ostream operator is not compatible with ceres::Jet types.
-// In particular, Eigen assumes that the scalar type (here Jet<T,N>) can be
-// casted to an arithmetic type, which is not true for ceres::Jet.
-// Unfortunatly, the ceres::Jet class does not define a conversion
-// operator (http://en.cppreference.com/w/cpp/language/cast_operator).
-//
-// This workaround creates a template specilization for Eigen's cast_impl,
-// when casting from a ceres::Jet type. It relies on Eigen's internal API and
-// might break with future versions of Eigen.
-namespace Eigen {
-namespace internal {
-
-template <class T, int N, typename NewType>
-struct cast_impl<ceres::Jet<T, N>, NewType> {
-  EIGEN_DEVICE_FUNC
-  static inline NewType run(ceres::Jet<T, N> const& x) {
-    return static_cast<NewType>(x.a);
-  }
-};
-
-}  // namespace internal
-}  // namespace Eigen
-
-struct TestSE3CostFunctor {
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  TestSE3CostFunctor(Sophus::SE3d T_aw) : T_aw(T_aw) {}
-
-  template <class T>
-  bool operator()(T const* const sT_wa, T* sResiduals) const {
-    Eigen::Map<Sophus::SE3<T> const> const T_wa(sT_wa);
-    Eigen::Map<Eigen::Matrix<T, 6, 1> > residuals(sResiduals);
-
-    // We are able to mix Sophus types with doubles and Jet types withou needing
-    // to cast to T.
-    residuals = (T_aw * T_wa).log();
-    // Reverse order of multiplication. This forces the compiler to verify that
-    // (Jet, double) and (double, Jet) SE3 multiplication work correctly.
-    residuals = (T_wa * T_aw).log();
-    // Finally, ensure that Jet-to-Jet multiplication works.
-    residuals = (T_wa * T_aw.cast<T>()).log();
-    return true;
-  }
-
-  Sophus::SE3d T_aw;
-};
-
-struct TestPointCostFunctor {
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  TestPointCostFunctor(Sophus::SE3d T_aw, Eigen::Vector3d point_a)
-      : T_aw(T_aw), point_a(point_a) {}
-
-  template <class T>
-  bool operator()(T const* const sT_wa, T const* const spoint_b,
-                  T* sResiduals) const {
-    using Vector3T = Eigen::Matrix<T, 3, 1>;
-    Eigen::Map<Sophus::SE3<T> const> const T_wa(sT_wa);
-    Eigen::Map<Vector3T const> point_b(spoint_b);
-    Eigen::Map<Vector3T> residuals(sResiduals);
-
-    // Multiply SE3d by Jet Vector3.
-    Vector3T point_b_prime = T_aw * point_b;
-    // Ensure Jet SE3 multiplication with Jet Vector3.
-    point_b_prime = T_aw.cast<T>() * point_b;
-
-    // Multiply Jet SE3 with Vector3d.
-    Vector3T point_a_prime = T_wa * point_a;
-    // Ensure Jet SE3 multiplication with Jet Vector3.
-    point_a_prime = T_wa * point_a.cast<T>();
-
-    residuals = point_b_prime - point_a_prime;
-    return true;
-  }
-
-  Sophus::SE3d T_aw;
-  Eigen::Vector3d point_a;
-};
-
-bool test(Sophus::SE3d const& T_w_targ, Sophus::SE3d const& T_w_init,
-          Sophus::SE3d::Point const& point_a_init,
-          Sophus::SE3d::Point const& point_b) {
-  static constexpr int kNumPointParameters = 3;
-
-  // Optimisation parameters.
-  Sophus::SE3d T_wr = T_w_init;
-  Sophus::SE3d::Point point_a = point_a_init;
-
-  // Build the problem.
-  ceres::Problem problem;
-
-  // Specify local update rule for our parameter
-  problem.AddParameterBlock(T_wr.data(), Sophus::SE3d::num_parameters,
-                            new Sophus::test::LocalParameterizationSE3);
-
-  // Create and add cost functions. Derivatives will be evaluated via
-  // automatic differentiation
-  ceres::CostFunction* cost_function1 =
-      new ceres::AutoDiffCostFunction<TestSE3CostFunctor, Sophus::SE3d::DoF,
-                                      Sophus::SE3d::num_parameters>(
-          new TestSE3CostFunctor(T_w_targ.inverse()));
-  problem.AddResidualBlock(cost_function1, NULL, T_wr.data());
-  ceres::CostFunction* cost_function2 =
-      new ceres::AutoDiffCostFunction<TestPointCostFunctor, kNumPointParameters,
-                                      Sophus::SE3d::num_parameters,
-                                      kNumPointParameters>(
-          new TestPointCostFunctor(T_w_targ.inverse(), point_b));
-  problem.AddResidualBlock(cost_function2, NULL, T_wr.data(), point_a.data());
-
-  // Set solver options (precision / method)
-  ceres::Solver::Options options;
-  options.gradient_tolerance = 0.01 * Sophus::Constants<double>::epsilon();
-  options.function_tolerance = 0.01 * Sophus::Constants<double>::epsilon();
-  options.linear_solver_type = ceres::DENSE_QR;
-
-  // Solve
-  ceres::Solver::Summary summary;
-  Solve(options, &problem, &summary);
-  std::cout << summary.BriefReport() << std::endl;
-
-  // Difference between target and parameter
-  double const mse = (T_w_targ.inverse() * T_wr).log().squaredNorm();
-  bool const passed = mse < 10. * Sophus::Constants<double>::epsilon();
-  return passed;
-}
-
-template <typename Scalar>
-bool CreateSE3FromMatrix(Eigen::Matrix<Scalar, 4, 4> mat) {
-  auto se3 = Sophus::SE3<Scalar>(mat);
-  se3 = se3;
-  return true;
-}
+template <typename T>
+using StdVector = std::vector<T, Eigen::aligned_allocator<T>>;
 
 int main(int, char**) {
-  using SE3Type = Sophus::SE3<double>;
-  using SO3Type = Sophus::SO3<double>;
-  using Point = SE3Type::Point;
+  using SE3d = Sophus::SE3d;
+  using SO3d = Sophus::SO3d;
+  using Point = SE3d::Point;
   double const kPi = Sophus::Constants<double>::pi();
 
-  std::vector<SE3Type> se3_vec;
-  se3_vec.push_back(
-      SE3Type(SO3Type::exp(Point(0.2, 0.5, 0.0)), Point(0, 0, 0)));
-  se3_vec.push_back(
-      SE3Type(SO3Type::exp(Point(0.2, 0.5, -1.0)), Point(10, 0, 0)));
-  se3_vec.push_back(SE3Type(SO3Type::exp(Point(0., 0., 0.)), Point(0, 100, 5)));
-  se3_vec.push_back(
-      SE3Type(SO3Type::exp(Point(0., 0., 0.00001)), Point(0, 0, 0)));
-  se3_vec.push_back(SE3Type(SO3Type::exp(Point(0., 0., 0.00001)),
-                            Point(0, -0.00000001, 0.0000000001)));
-  se3_vec.push_back(
-      SE3Type(SO3Type::exp(Point(0., 0., 0.00001)), Point(0.01, 0, 0)));
-  se3_vec.push_back(SE3Type(SO3Type::exp(Point(kPi, 0, 0)), Point(4, -5, 0)));
-  se3_vec.push_back(
-      SE3Type(SO3Type::exp(Point(0.2, 0.5, 0.0)), Point(0, 0, 0)) *
-      SE3Type(SO3Type::exp(Point(kPi, 0, 0)), Point(0, 0, 0)) *
-      SE3Type(SO3Type::exp(Point(-0.2, -0.5, -0.0)), Point(0, 0, 0)));
-  se3_vec.push_back(
-      SE3Type(SO3Type::exp(Point(0.3, 0.5, 0.1)), Point(2, 0, -7)) *
-      SE3Type(SO3Type::exp(Point(kPi, 0, 0)), Point(0, 0, 0)) *
-      SE3Type(SO3Type::exp(Point(-0.3, -0.5, -0.1)), Point(0, 6, 0)));
+  StdVector<SE3d> se3_vec = {
+      SE3d(SO3d::exp(Point(0.2, 0.5, 0.0)), Point(0, 0, 0)),
+      SE3d(SO3d::exp(Point(0.2, 0.5, -1.0)), Point(10, 0, 0)),
+      SE3d(SO3d::exp(Point(0., 0., 0.)), Point(0, 100, 5)),
+      SE3d(SO3d::exp(Point(0., 0., 0.00001)), Point(0, 0, 0)),
+      SE3d(SO3d::exp(Point(0., 0., 0.00001)),
+           Point(0, -0.00000001, 0.0000000001)),
+      SE3d(SO3d::exp(Point(0., 0., 0.00001)), Point(0.01, 0, 0)),
+      SE3d(SO3d::exp(Point(kPi, 0, 0)), Point(4, -5, 0)),
+      SE3d(SO3d::exp(Point(0.2, 0.5, 0.0)), Point(0, 0, 0)) *
+          SE3d(SO3d::exp(Point(kPi, 0, 0)), Point(0, 0, 0)) *
+          SE3d(SO3d::exp(Point(-0.2, -0.5, -0.0)), Point(0, 0, 0)),
+      SE3d(SO3d::exp(Point(0.3, 0.5, 0.1)), Point(2, 0, -7)) *
+          SE3d(SO3d::exp(Point(kPi, 0, 0)), Point(0, 0, 0)) *
+          SE3d(SO3d::exp(Point(-0.3, -0.5, -0.1)), Point(0, 6, 0))};
 
-  std::vector<Point> point_vec;
-  point_vec.emplace_back(1.012, 2.73, -1.4);
-  point_vec.emplace_back(9.2, -7.3, -4.4);
-  point_vec.emplace_back(2.5, 0.1, 9.1);
-  point_vec.emplace_back(12.3, 1.9, 3.8);
-  point_vec.emplace_back(-3.21, 3.42, 2.3);
-  point_vec.emplace_back(-8.0, 6.1, -1.1);
-  point_vec.emplace_back(0.0, 2.5, 5.9);
-  point_vec.emplace_back(7.1, 7.8, -14);
-  point_vec.emplace_back(5.8, 9.2, 0.0);
+  StdVector<Point> point_vec = {
+      Point(1.012, 2.73, -1.4), Point(9.2, -7.3, -4.4),  Point(2.5, 0.1, 9.1),
+      Point(12.3, 1.9, 3.8),    Point(-3.21, 3.42, 2.3), Point(-8.0, 6.1, -1.1),
+      Point(0.0, 2.5, 5.9),     Point(7.1, 7.8, -14),    Point(5.8, 9.2, 0.0),
+  };
 
-  for (size_t i = 0; i < se3_vec.size(); ++i) {
-    const int other_index = (i + 3) % se3_vec.size();
-    bool const passed = test(se3_vec[i], se3_vec[other_index], point_vec[i],
-                             point_vec[other_index]);
-    if (!passed) {
-      std::cerr << "failed!" << std::endl << std::endl;
-      exit(-1);
-    }
-  }
-
-  Eigen::Matrix<ceres::Jet<double, 28>, 4, 4> mat;
-  mat.setIdentity();
-  std::cout << CreateSE3FromMatrix(mat) << std::endl;
-
+  Sophus::LieGroupCeresTests<Sophus::SE3>(se3_vec, point_vec).testAll();
   return 0;
 }

--- a/test/ceres/test_ceres_sim2.cpp
+++ b/test/ceres/test_ceres_sim2.cpp
@@ -1,0 +1,49 @@
+#include <ceres/ceres.h>
+#include <iostream>
+#include <sophus/sim2.hpp>
+
+#include "tests.hpp"
+
+template <typename T>
+using StdVector = std::vector<T, Eigen::aligned_allocator<T>>;
+
+int main(int, char**) {
+  using Sim2d = Sophus::Sim2d;
+  using RxSO2d = Sophus::RxSO2d;
+  using Point = Sim2d::Point;
+  using Vector2d = Sophus::Vector2d;
+  double const kPi = Sophus::Constants<double>::pi();
+
+  StdVector<Sim2d> sim2_vec = {
+
+      Sim2d(RxSO2d::exp(Vector2d(0.2, 1.)), Point(0, 0)),
+
+      Sim2d(RxSO2d::exp(Vector2d(0.2, 1.1)), Point(10, 0)),
+
+      Sim2d(RxSO2d::exp(Vector2d(0., 0.)), Point(0, 10)),
+
+      Sim2d(RxSO2d::exp(Vector2d(0.00001, 0.)), Point(0, 0)),
+
+      Sim2d(RxSO2d::exp(Vector2d(0.00001, 0.0000001)), Point(1, -1.00000001)),
+
+      Sim2d(RxSO2d::exp(Vector2d(0., 0.)), Point(0.01, 0)),
+
+      Sim2d(RxSO2d::exp(Vector2d(kPi, 0.9)), Point(4, 0)),
+
+      Sim2d(RxSO2d::exp(Vector2d(0.2, 0)), Point(0, 0)) *
+          Sim2d(RxSO2d::exp(Vector2d(kPi, 0)), Point(0, 0)) *
+          Sim2d(RxSO2d::exp(Vector2d(-0.2, 0)), Point(0, 0)),
+
+      Sim2d(RxSO2d::exp(Vector2d(0.3, 0)), Point(2, -7)) *
+          Sim2d(RxSO2d::exp(Vector2d(kPi, 0)), Point(0, 0)) *
+          Sim2d(RxSO2d::exp(Vector2d(-0.3, 0)), Point(0, 6)),
+  };
+
+  StdVector<Point> point_vec = {
+      Point(1.012, 2.73), Point(9.2, -7.3),   Point(2.5, 0.1),
+      Point(12.3, 1.9),   Point(-3.21, 3.42), Point(-8.0, 6.1),
+      Point(0.0, 2.5),    Point(7.1, 7.8),    Point(5.8, 9.2)};
+
+  Sophus::LieGroupCeresTests<Sophus::Sim2>(sim2_vec, point_vec).testAll();
+  return 0;
+}

--- a/test/ceres/test_ceres_sim3.cpp
+++ b/test/ceres/test_ceres_sim3.cpp
@@ -1,0 +1,42 @@
+#include <ceres/ceres.h>
+#include <iostream>
+#include <sophus/sim3.hpp>
+
+#include "tests.hpp"
+
+template <typename T>
+using StdVector = std::vector<T, Eigen::aligned_allocator<T>>;
+
+int main(int, char**) {
+  using RxSO3d = Sophus::RxSO3d;
+  using Sim3d = Sophus::Sim3d;
+  using Point = Sim3d::Point;
+  using Vector4d = Eigen::Vector4d;
+  double const kPi = Sophus::Constants<double>::pi();
+
+  StdVector<Sim3d> sim3_vec = {
+      Sim3d(RxSO3d::exp(Vector4d(0.2, 0.5, 0.0, 1.)), Point(0, 0, 0)),
+      Sim3d(RxSO3d::exp(Vector4d(0.2, 0.5, -1.0, 1.1)), Point(10, 0, 0)),
+      Sim3d(RxSO3d::exp(Vector4d(0., 0., 0., 0.001)), Point(0, 10, 5)),
+      Sim3d(RxSO3d::exp(Vector4d(0., 0., 0., 1.1)), Point(0, 10, 5)),
+      Sim3d(RxSO3d::exp(Vector4d(0., 0., 0.00001, 0.)), Point(0, 0, 0)),
+      Sim3d(RxSO3d::exp(Vector4d(0., 0., 0.00001, 0.0000001)),
+            Point(1, -1.00000001, 2.0000000001)),
+      Sim3d(RxSO3d::exp(Vector4d(0., 0., 0.00001, 0)), Point(0.01, 0, 0)),
+      Sim3d(RxSO3d::exp(Vector4d(kPi, 0, 0, 0.9)), Point(4, -5, 0)),
+      Sim3d(RxSO3d::exp(Vector4d(0.2, 0.5, 0.0, 0)), Point(0, 0, 0)) *
+          Sim3d(RxSO3d::exp(Vector4d(kPi, 0, 0, 0)), Point(0, 0, 0)) *
+          Sim3d(RxSO3d::exp(Vector4d(-0.2, -0.5, -0.0, 0)), Point(0, 0, 0)),
+      Sim3d(RxSO3d::exp(Vector4d(0.3, 0.5, 0.1, 0)), Point(2, 0, -7)) *
+          Sim3d(RxSO3d::exp(Vector4d(kPi, 0, 0, 0)), Point(0, 0, 0)) *
+          Sim3d(RxSO3d::exp(Vector4d(-0.3, -0.5, -0.1, 0)), Point(0, 6, 0))};
+
+  StdVector<Point> point_vec = {
+      Point(1.012, 2.73, -1.4), Point(9.2, -7.3, -4.4),  Point(2.5, 0.1, 9.1),
+      Point(12.3, 1.9, 3.8),    Point(-3.21, 3.42, 2.3), Point(-8.0, 6.1, -1.1),
+      Point(0.0, 2.5, 5.9),     Point(7.1, 7.8, -14),    Point(5.8, 9.2, 0.0),
+  };
+
+  Sophus::LieGroupCeresTests<Sophus::Sim3>(sim3_vec, point_vec).testAll();
+  return 0;
+}

--- a/test/ceres/test_ceres_so2.cpp
+++ b/test/ceres/test_ceres_so2.cpp
@@ -1,0 +1,30 @@
+#include <ceres/ceres.h>
+#include <iostream>
+#include <sophus/so2.hpp>
+
+#include "tests.hpp"
+
+template <typename T>
+using StdVector = std::vector<T, Eigen::aligned_allocator<T>>;
+
+int main(int, char**) {
+  using SO2d = Sophus::SO2d;
+  using Point = SO2d::Point;
+  double const kPi = Sophus::Constants<double>::pi();
+
+  StdVector<SO2d> so2_vec = {SO2d::exp(0.0),
+                             SO2d::exp(0.2),
+                             SO2d::exp(10.),
+                             SO2d::exp(0.00001),
+                             SO2d::exp(kPi),
+                             SO2d::exp(0.2) * SO2d::exp(kPi) * SO2d::exp(-0.2),
+                             SO2d::exp(-0.3) * SO2d::exp(kPi) * SO2d::exp(0.3)};
+
+  StdVector<Point> point_vec = {
+      Point(1.012, 2.73), Point(9.2, -7.3),   Point(2.5, 0.1),
+      Point(12.3, 1.9),   Point(-3.21, 3.42), Point(-8.0, 6.1),
+      Point(0.0, 2.5),    Point(7.1, 7.8),    Point(5.8, 9.2)};
+
+  Sophus::LieGroupCeresTests<Sophus::SO2>(so2_vec, point_vec).testAll();
+  return 0;
+}

--- a/test/ceres/test_ceres_so3.cpp
+++ b/test/ceres/test_ceres_so3.cpp
@@ -1,0 +1,33 @@
+#include <ceres/ceres.h>
+#include <iostream>
+#include <sophus/se3.hpp>
+
+#include "tests.hpp"
+
+template <typename T>
+using StdVector = std::vector<T, Eigen::aligned_allocator<T>>;
+
+int main(int, char**) {
+  using SO3d = Sophus::SO3d;
+  using Point = SO3d::Point;
+  double const kPi = Sophus::Constants<double>::pi();
+
+  StdVector<SO3d> so3_vec = {
+      SO3d::exp(Point(0.2, 0.5, 0.0)),
+      SO3d::exp(Point(0.2, 0.5, -1.0)),
+      SO3d::exp(Point(0., 0., 0.)),
+      SO3d::exp(Point(0., 0., 0.00001)),
+      SO3d::exp(Point(kPi, 0, 0)),
+      SO3d::exp(Point(0.2, 0.5, 0.0)) * SO3d::exp(Point(kPi, 0, 0)) *
+          SO3d::exp(Point(-0.2, -0.5, -0.0)),
+      SO3d::exp(Point(0.3, 0.5, 0.1)) * SO3d::exp(Point(kPi, 0, 0)) *
+          SO3d::exp(Point(-0.3, -0.5, -0.1))};
+
+  StdVector<Point> point_vec = {
+      Point(1.012, 2.73, -1.4), Point(9.2, -7.3, -4.4),  Point(2.5, 0.1, 9.1),
+      Point(12.3, 1.9, 3.8),    Point(-3.21, 3.42, 2.3), Point(-8.0, 6.1, -1.1),
+      Point(0.0, 2.5, 5.9),     Point(7.1, 7.8, -14),    Point(5.8, 9.2, 0.0)};
+
+  Sophus::LieGroupCeresTests<Sophus::SO3>(so3_vec, point_vec).testAll();
+  return 0;
+}

--- a/test/ceres/tests.hpp
+++ b/test/ceres/tests.hpp
@@ -1,0 +1,159 @@
+#ifndef SOPHUS_CERES_TESTS_HPP
+#define SOPHUS_CERES_TESTS_HPP
+
+#include <ceres/ceres.h>
+
+#include <sophus/ceres_local_parameterization.hpp>
+
+namespace Sophus {
+
+template <int N>
+double squaredNorm(const Vector<double, N>& vec) {
+  return vec.squaredNorm();
+}
+
+double squaredNorm(const double& scalar) { return scalar * scalar; }
+
+template <template <typename, int = 0> class LieGroup_>
+struct LieGroupCeresTests {
+  template <typename T>
+  using LieGroup = LieGroup_<T>;
+  using LieGroupd = LieGroup<double>;
+  using Pointd = typename LieGroupd::Point;
+  template <typename T>
+  using StdVector = std::vector<T, Eigen::aligned_allocator<T>>;
+  static int constexpr N = LieGroupd::N;
+  static int constexpr num_parameters = LieGroupd::num_parameters;
+  static int constexpr DoF = LieGroupd::DoF;
+
+  struct TestLieGroupCostFunctor {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    TestLieGroupCostFunctor(const LieGroupd& T_aw) : T_aw(T_aw) {}
+
+    template <class T>
+    bool operator()(T const* const sT_wa, T* sResiduals) const {
+      Eigen::Map<LieGroup<T> const> const T_wa(sT_wa);
+      Eigen::Map<typename LieGroup<T>::Tangent> residuals(sResiduals);
+
+      // We are able to mix Sophus types with doubles and Jet types withou
+      // needing to cast to T.
+      residuals = (T_aw * T_wa).log();
+      // Reverse order of multiplication. This forces the compiler to verify
+      // that (Jet, double) and (double, Jet) LieGroup multiplication work
+      // correctly.
+      residuals = (T_wa * T_aw).log();
+      // Finally, ensure that Jet-to-Jet multiplication works.
+      residuals = (T_wa * T_aw.template cast<T>()).log();
+      return true;
+    }
+
+    LieGroupd T_aw;
+  };
+  struct TestPointCostFunctor {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    TestPointCostFunctor(const LieGroupd& T_aw, const Pointd& point_a)
+        : T_aw(T_aw), point_a(point_a) {}
+
+    template <class T>
+    bool operator()(T const* const sT_wa, T const* const spoint_b,
+                    T* sResiduals) const {
+      using LieGroupT = LieGroup<T>;
+      using PointT = typename LieGroupT::Point;
+      Eigen::Map<LieGroupT const> const T_wa(sT_wa);
+      Eigen::Map<PointT const> point_b(spoint_b);
+      Eigen::Map<PointT> residuals(sResiduals);
+
+      // Multiply LieGroupd by Jet Vector3.
+      PointT point_b_prime = T_aw * point_b;
+      // Ensure Jet LieGroup multiplication with Jet Vector3.
+      point_b_prime = T_aw.template cast<T>() * point_b;
+
+      // Multiply Jet LieGroup with Vector3d.
+      PointT point_a_prime = T_wa * point_a;
+      // Ensure Jet LieGroup multiplication with Jet Vector3.
+      point_a_prime = T_wa * point_a.template cast<T>();
+
+      residuals = point_b_prime - point_a_prime;
+      return true;
+    }
+
+    LieGroupd T_aw;
+    Pointd point_a;
+  };
+
+  bool testAll() {
+    bool passed = true;
+    for (size_t i = 0; i < group_vec.size(); ++i) {
+      for (size_t j = 0; j < group_vec.size(); ++j) {
+        if (i == j) continue;
+        for (size_t k = 0; k < point_vec.size(); ++k) {
+          for (size_t l = 0; l < point_vec.size(); ++l) {
+            if (k == l) continue;
+            passed &=
+                test(group_vec[i], group_vec[j], point_vec[k], point_vec[l]);
+          }
+        }
+      }
+    }
+    return passed;
+  }
+
+  bool test(LieGroupd const& T_w_targ, LieGroupd const& T_w_init,
+            Pointd const& point_a_init, Pointd const& point_b) {
+    static constexpr int kNumPointParameters = Pointd::RowsAtCompileTime;
+
+    // Optimisation parameters.
+    LieGroupd T_wr = T_w_init;
+    Pointd point_a = point_a_init;
+
+    // Build the problem.
+    ceres::Problem problem;
+
+    // Specify local update rule for our parameter
+    problem.AddParameterBlock(T_wr.data(), num_parameters,
+                              new Sophus::LocalParameterization<LieGroup_>);
+
+    // Create and add cost functions. Derivatives will be evaluated via
+    // automatic differentiation
+    ceres::CostFunction* cost_function1 =
+        new ceres::AutoDiffCostFunction<TestLieGroupCostFunctor, LieGroupd::DoF,
+                                        LieGroupd::num_parameters>(
+            new TestLieGroupCostFunctor(T_w_targ.inverse()));
+    problem.AddResidualBlock(cost_function1, NULL, T_wr.data());
+    ceres::CostFunction* cost_function2 =
+        new ceres::AutoDiffCostFunction<TestPointCostFunctor,
+                                        kNumPointParameters, num_parameters,
+                                        kNumPointParameters>(
+            new TestPointCostFunctor(T_w_targ.inverse(), point_b));
+    problem.AddResidualBlock(cost_function2, NULL, T_wr.data(), point_a.data());
+
+    // Set solver options (precision / method)
+    ceres::Solver::Options options;
+    options.gradient_tolerance = 0.01 * Sophus::Constants<double>::epsilon();
+    options.function_tolerance = 0.01 * Sophus::Constants<double>::epsilon();
+    options.linear_solver_type = ceres::DENSE_QR;
+
+    // Solve
+    ceres::Solver::Summary summary;
+    Solve(options, &problem, &summary);
+    std::cout << summary.BriefReport() << std::endl;
+
+    // Difference between target and parameter
+    double const mse = squaredNorm((T_w_targ.inverse() * T_wr).log());
+    bool const passed = mse < 10. * Sophus::Constants<double>::epsilon();
+    return passed;
+  }
+
+  LieGroupCeresTests(const StdVector<LieGroupd>& group_vec,
+                     const StdVector<Pointd>& point_vec)
+      : group_vec(group_vec), point_vec(point_vec) {}
+
+  StdVector<LieGroupd> group_vec;
+  StdVector<Pointd> point_vec;
+};
+
+}  // namespace Sophus
+
+#endif

--- a/test/core/test_rxso2.cpp
+++ b/test/core/test_rxso2.cpp
@@ -107,7 +107,7 @@ class Tests {
                      SO2Type::exp(Constants<Scalar>::pi()));
     RxSO2Type saturated_product = small1 * small2;
     SOPHUS_TEST_APPROX(passed, saturated_product.scale(),
-                       Constants<Scalar>::epsilon(),
+                       Scalar(2.0) * Constants<Scalar>::epsilon(),
                        Constants<Scalar>::epsilon());
     SOPHUS_TEST_APPROX(passed, saturated_product.so2().matrix(),
                        (small1.so2() * small2.so2()).matrix(),

--- a/test/core/test_rxso3.cpp
+++ b/test/core/test_rxso3.cpp
@@ -92,6 +92,7 @@ class Tests {
   }
 
   bool testSaturation() {
+    using std::sqrt;
     bool passed = true;
     RxSO3Type small1(Constants<Scalar>::epsilon(), SO3Type());
     RxSO3Type small2(Constants<Scalar>::epsilon(),
@@ -99,7 +100,7 @@ class Tests {
                                                   Scalar(0), Scalar(0))));
     RxSO3Type saturated_product = small1 * small2;
     SOPHUS_TEST_APPROX(passed, saturated_product.scale(),
-                       Constants<Scalar>::epsilon(),
+                       sqrt(Scalar(2.0)) * Constants<Scalar>::epsilon(),
                        Constants<Scalar>::epsilon());
     SOPHUS_TEST_APPROX(passed, saturated_product.so3().matrix(),
                        (small1.so3() * small2.so3()).matrix(),

--- a/test/core/test_se2.cpp
+++ b/test/core/test_se2.cpp
@@ -159,7 +159,7 @@ class Tests {
     Point translation = se2.translation();
     SO2Type so2 = se2.so2();
 
-    SOPHUS_TEST_APPROX(passed, SE2Type(so2.log(), translation).matrix(),
+    SOPHUS_TEST_APPROX(passed, SE2Type(so2.log()[0], translation).matrix(),
                        se2.matrix(), Constants<Scalar>::epsilon());
     SOPHUS_TEST_APPROX(passed, SE2Type(so2, translation).matrix(), se2.matrix(),
                        Constants<Scalar>::epsilon());

--- a/test/core/test_sim2.cpp
+++ b/test/core/test_sim2.cpp
@@ -59,6 +59,10 @@ class Tests {
     tangent_vec_.push_back(tmp);
     tmp << Scalar(1), Scalar(0), Scalar(0), Scalar(0);
     tangent_vec_.push_back(tmp);
+    tmp << Scalar(0), Scalar(0), Scalar(1), Scalar(0);
+    tangent_vec_.push_back(tmp);
+    tmp << Scalar(0), Scalar(0), Scalar(1), Scalar(0.1);
+    tangent_vec_.push_back(tmp);
     tmp << Scalar(0), Scalar(1), Scalar(0), Scalar(0.1);
     tangent_vec_.push_back(tmp);
     tmp << Scalar(-1), Scalar(1), Scalar(1), Scalar(-0.1);

--- a/test/core/test_sim3.cpp
+++ b/test/core/test_sim3.cpp
@@ -90,6 +90,12 @@ class Tests {
         Scalar(0);
     tangent_vec_.push_back(tmp);
     tmp << Scalar(0), Scalar(1), Scalar(0), Scalar(1), Scalar(0), Scalar(0),
+        Scalar(0);
+    tangent_vec_.push_back(tmp);
+    tmp << Scalar(0), Scalar(1), Scalar(0), Scalar(0), Scalar(0), Scalar(0),
+        Scalar(1);
+    tangent_vec_.push_back(tmp);
+    tmp << Scalar(0), Scalar(1), Scalar(0), Scalar(1), Scalar(0), Scalar(0),
         Scalar(0.1);
     tangent_vec_.push_back(tmp);
     tmp << Scalar(0), Scalar(0), Scalar(1), Scalar(0), Scalar(1), Scalar(0),

--- a/test/core/tests.hpp
+++ b/test/core/tests.hpp
@@ -132,12 +132,7 @@ class LieGroupTests {
   }
 
   template <class G = LieGroup>
-  enable_if_t<std::is_same<G, Sophus::SO2<Scalar>>::value ||
-                  std::is_same<G, Sophus::SO3<Scalar>>::value ||
-                  std::is_same<G, Sophus::SE2<Scalar>>::value ||
-                  std::is_same<G, Sophus::SE3<Scalar>>::value,
-              bool>
-  additionalDerivativeTest() {
+  bool additionalDerivativeTest() {
     bool passed = true;
     for (size_t j = 0; j < tangent_vec_.size(); ++j) {
       Tangent a = tangent_vec_[j];
@@ -182,16 +177,6 @@ class LieGroupTests {
     return passed;
   }
 
-  template <class G = LieGroup>
-  enable_if_t<!std::is_same<G, Sophus::SO2<Scalar>>::value &&
-                  !std::is_same<G, Sophus::SO3<Scalar>>::value &&
-                  !std::is_same<G, Sophus::SE2<Scalar>>::value &&
-                  !std::is_same<G, Sophus::SE3<Scalar>>::value,
-              bool>
-  additionalDerivativeTest() {
-    return true;
-  }
-
   bool productTest() {
     bool passed = true;
 
@@ -200,7 +185,8 @@ class LieGroupTests {
       LieGroup T2 = group_vec_[i + 1];
       LieGroup mult = T1 * T2;
       T1 *= T2;
-      SOPHUS_TEST_APPROX(passed, T1.matrix(), mult.matrix(), kSmallEps, "Product case: %", i);
+      SOPHUS_TEST_APPROX(passed, T1.matrix(), mult.matrix(), kSmallEps,
+                         "Product case: %", i);
     }
     return passed;
   }


### PR DESCRIPTION
This adds:
* Generic `ceres::LocalParameterization` (and corresponding tests) for all groups from `Sophus`
* `exp(x)`,`this*exp(x)` derivatives for `RxSO2`, `RxSO3`, `Sim2`, `Sim3`


There are some changes that, potentially, require more discussion:
* Saturation behavior is changed for `RxSO2`/`RxSO3` in order to get it more numerically "stable".
* I've changed `SO2::Tangent` to `Vector1` for easier interoperability; not sure if it is 'beautiful'; probably I should change it back to `Scalar` (and add ad-hoc handling here and there)