### PR TITLE
Remove M_PI

### DIFF
--- a/sophus/common.hpp
+++ b/sophus/common.hpp
@@ -151,7 +151,9 @@ struct Constants {
     return sqrt(epsilon());
   }
 
-  SOPHUS_FUNC static Scalar pi() { return Scalar(M_PI); }
+  SOPHUS_FUNC static Scalar pi() {
+    return Scalar(3.141592653589793238462643383279502884);
+  }
 };
 
 template <>
@@ -162,7 +164,9 @@ struct Constants<float> {
 
   SOPHUS_FUNC static float epsilonSqrt() { return std::sqrt(epsilon()); }
 
-  SOPHUS_FUNC static float constexpr pi() { return static_cast<float>(M_PI); }
+  SOPHUS_FUNC static float constexpr pi() {
+    return 3.141592653589793238462643383279502884f;
+  }
 };
 
 /// Nullopt type of lightweight optional class.


### PR DESCRIPTION
A #define for M_PI is not guaranteed by the standard, even though many C standard library implementations provide it in math.h. Increase portability by replacing this reference to a non-standard symbol.