### PR TITLE
Fix bug with rotationMatrix() / setRotationMatrix() for Map types.

### DIFF
--- a/sophus/rxso2.hpp
+++ b/sophus/rxso2.hpp
@@ -16,22 +16,25 @@ using RxSO2f = RxSO2<float>;
 namespace Eigen {
 namespace internal {
 
-template <class Scalar_, int Options>
-struct traits<Sophus::RxSO2<Scalar_, Options>> {
+template <class Scalar_, int Options_>
+struct traits<Sophus::RxSO2<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
   using Scalar = Scalar_;
   using ComplexType = Sophus::Vector2<Scalar, Options>;
 };
 
-template <class Scalar_, int Options>
-struct traits<Map<Sophus::RxSO2<Scalar_>, Options>>
-    : traits<Sophus::RxSO2<Scalar_, Options>> {
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::RxSO2<Scalar_>, Options_>>
+    : traits<Sophus::RxSO2<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
   using Scalar = Scalar_;
   using ComplexType = Map<Sophus::Vector2<Scalar>, Options>;
 };
 
-template <class Scalar_, int Options>
-struct traits<Map<Sophus::RxSO2<Scalar_> const, Options>>
-    : traits<Sophus::RxSO2<Scalar_, Options> const> {
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::RxSO2<Scalar_> const, Options_>>
+    : traits<Sophus::RxSO2<Scalar_, Options_> const> {
+  static constexpr int Options = Options_;
   using Scalar = Scalar_;
   using ComplexType = Map<Sophus::Vector2<Scalar> const, Options>;
 };
@@ -75,8 +78,10 @@ namespace Sophus {
 template <class Derived>
 class RxSO2Base {
  public:
+  static constexpr int Options = Eigen::internal::traits<Derived>::Options;
   using Scalar = typename Eigen::internal::traits<Derived>::Scalar;
   using ComplexType = typename Eigen::internal::traits<Derived>::ComplexType;
+  using ComplexTemporaryType = Sophus::Vector2<Scalar, Options>;
 
   /// Degrees of freedom of manifold, number of dimensions in tangent space
   /// (one for rotation and one for scaling).
@@ -309,7 +314,7 @@ class RxSO2Base {
   /// Returns rotation matrix.
   ///
   SOPHUS_FUNC Transformation rotationMatrix() const {
-    ComplexType norm_quad = complex();
+    ComplexTemporaryType norm_quad = complex();
     norm_quad.normalize();
     return SO2<Scalar>(norm_quad).matrix();
   }

--- a/sophus/rxso3.hpp
+++ b/sophus/rxso3.hpp
@@ -16,22 +16,25 @@ using RxSO3f = RxSO3<float>;
 namespace Eigen {
 namespace internal {
 
-template <class Scalar_, int Options>
-struct traits<Sophus::RxSO3<Scalar_, Options>> {
+template <class Scalar_, int Options_>
+struct traits<Sophus::RxSO3<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
   using Scalar = Scalar_;
   using QuaternionType = Eigen::Quaternion<Scalar, Options>;
 };
 
-template <class Scalar_, int Options>
-struct traits<Map<Sophus::RxSO3<Scalar_>, Options>>
-    : traits<Sophus::RxSO3<Scalar_, Options>> {
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::RxSO3<Scalar_>, Options_>>
+    : traits<Sophus::RxSO3<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
   using Scalar = Scalar_;
   using QuaternionType = Map<Eigen::Quaternion<Scalar>, Options>;
 };
 
-template <class Scalar_, int Options>
-struct traits<Map<Sophus::RxSO3<Scalar_> const, Options>>
-    : traits<Sophus::RxSO3<Scalar_, Options> const> {
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::RxSO3<Scalar_> const, Options_>>
+    : traits<Sophus::RxSO3<Scalar_, Options_> const> {
+  static constexpr int Options = Options_;
   using Scalar = Scalar_;
   using QuaternionType = Map<Eigen::Quaternion<Scalar> const, Options>;
 };
@@ -66,9 +69,11 @@ namespace Sophus {
 template <class Derived>
 class RxSO3Base {
  public:
+  static constexpr int Options = Eigen::internal::traits<Derived>::Options;
   using Scalar = typename Eigen::internal::traits<Derived>::Scalar;
   using QuaternionType =
       typename Eigen::internal::traits<Derived>::QuaternionType;
+  using QuaternionTemporaryType = Eigen::Quaternion<Scalar, Options>;
 
   /// Degrees of freedom of manifold, number of dimensions in tangent space
   /// (three for rotation and one for scaling).
@@ -338,7 +343,7 @@ class RxSO3Base {
   /// Returns rotation matrix.
   ///
   SOPHUS_FUNC Transformation rotationMatrix() const {
-    QuaternionType norm_quad = quaternion();
+    QuaternionTemporaryType norm_quad = quaternion();
     norm_quad.normalize();
     return norm_quad.toRotationMatrix();
   }

--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -320,8 +320,8 @@ class SE2Base {
     SOPHUS_ENSURE(isOrthogonal(R), "R is not orthogonal:\n %", R);
     SOPHUS_ENSURE(R.determinant() > Scalar(0), "det(R) is not positive: %",
                   R.determinant());
-    typename SO2Type::ComplexT const complex(Scalar(0.5) * (R(0, 0) + R(1, 1)),
-                                             Scalar(0.5) * (R(1, 0) - R(0, 1)));
+    typename SO2Type::ComplexTemporaryType const complex(
+        Scalar(0.5) * (R(0, 0) + R(1, 1)), Scalar(0.5) * (R(1, 0) - R(0, 1)));
     so2().setComplex(complex);
   }
 

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -24,22 +24,25 @@ using SO2f = SO2<float>;
 namespace Eigen {
 namespace internal {
 
-template <class Scalar_, int Options>
-struct traits<Sophus::SO2<Scalar_, Options>> {
+template <class Scalar_, int Options_>
+struct traits<Sophus::SO2<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
   using Scalar = Scalar_;
   using ComplexType = Sophus::Vector2<Scalar, Options>;
 };
 
-template <class Scalar_, int Options>
-struct traits<Map<Sophus::SO2<Scalar_>, Options>>
-    : traits<Sophus::SO2<Scalar_, Options>> {
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::SO2<Scalar_>, Options_>>
+    : traits<Sophus::SO2<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
   using Scalar = Scalar_;
   using ComplexType = Map<Sophus::Vector2<Scalar>, Options>;
 };
 
-template <class Scalar_, int Options>
-struct traits<Map<Sophus::SO2<Scalar_> const, Options>>
-    : traits<Sophus::SO2<Scalar_, Options> const> {
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::SO2<Scalar_> const, Options_>>
+    : traits<Sophus::SO2<Scalar_, Options_> const> {
+  static constexpr int Options = Options_;
   using Scalar = Scalar_;
   using ComplexType = Map<Sophus::Vector2<Scalar> const, Options>;
 };
@@ -76,8 +79,10 @@ namespace Sophus {
 template <class Derived>
 class SO2Base {
  public:
+  static constexpr int Options = Eigen::internal::traits<Derived>::Options;
   using Scalar = typename Eigen::internal::traits<Derived>::Scalar;
   using ComplexT = typename Eigen::internal::traits<Derived>::ComplexType;
+  using ComplexTemporaryType = Sophus::Vector2<Scalar, Options>;
 
   /// Degrees of freedom of manifold, number of dimensions in tangent space (one
   /// since we only have in-plane rotations).

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -24,22 +24,25 @@ using SO3f = SO3<float>;
 namespace Eigen {
 namespace internal {
 
-template <class Scalar_, int Options>
-struct traits<Sophus::SO3<Scalar_, Options>> {
+template <class Scalar_, int Options_>
+struct traits<Sophus::SO3<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
   using Scalar = Scalar_;
   using QuaternionType = Eigen::Quaternion<Scalar, Options>;
 };
 
-template <class Scalar_, int Options>
-struct traits<Map<Sophus::SO3<Scalar_>, Options>>
-    : traits<Sophus::SO3<Scalar_, Options>> {
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::SO3<Scalar_>, Options_>>
+    : traits<Sophus::SO3<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
   using Scalar = Scalar_;
   using QuaternionType = Map<Eigen::Quaternion<Scalar>, Options>;
 };
 
-template <class Scalar_, int Options>
-struct traits<Map<Sophus::SO3<Scalar_> const, Options>>
-    : traits<Sophus::SO3<Scalar_, Options> const> {
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::SO3<Scalar_> const, Options_>>
+    : traits<Sophus::SO3<Scalar_, Options_> const> {
+  static constexpr int Options = Options_;
   using Scalar = Scalar_;
   using QuaternionType = Map<Eigen::Quaternion<Scalar> const, Options>;
 };
@@ -73,9 +76,11 @@ namespace Sophus {
 template <class Derived>
 class SO3Base {
  public:
+  static constexpr int Options = Eigen::internal::traits<Derived>::Options;
   using Scalar = typename Eigen::internal::traits<Derived>::Scalar;
   using QuaternionType =
       typename Eigen::internal::traits<Derived>::QuaternionType;
+  using QuaternionTemporaryType = Eigen::Quaternion<Scalar, Options>;
 
   /// Degrees of freedom of group, number of dimensions in tangent space.
   static int constexpr DoF = 3;

--- a/test/core/test_se2.cpp
+++ b/test/core/test_se2.cpp
@@ -160,6 +160,13 @@ class Tests {
     SOPHUS_TEST_APPROX(passed, se2.rotationMatrix(), R.matrix(),
                        Constants<Scalar>::epsilon());
 
+    Eigen::Matrix<Scalar, 4, 1> raw;
+    raw << Scalar(1), Scalar(0), Scalar(3), Scalar(1);
+    Eigen::Map<SE2Type> map_of_se2(raw.data());
+    map_of_se2.setRotationMatrix(R.matrix());
+    SOPHUS_TEST_APPROX(passed, map_of_se2.rotationMatrix(), R.matrix(),
+                       Constants<Scalar>::epsilon());
+
     return passed;
   }
 


### PR DESCRIPTION
Introduce new typedef ComplexTemporaryType / QuaternionTemporaryType which can be used for temporary expressions also for Map types, where ComplexType / QuaternionType is also a Map.

Fixes the following bugs and adds regression tests:
- RxSE2/3, Sim2/3: For Map types calling rotationMatrix() wrongly normalizes the stored quaternion.
- RxSE2/3, Sim2/3: For const Map types calling rotationMatrix() doesn't compile.
- SE2: For Map types setRotationMatrix() doesn't compile.

**Update:** Fixed wrong usage of ComplexTemporaryType and add test for setRotationMatrix for Map.