### PR TITLE
New version - 1.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.4)
-project(Sophus VERSION 1.0.0)
+project(Sophus VERSION 1.1.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>sophus</name>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
   <description>
    C++ implementation of Lie Groups using Eigen.
   </description>


### PR DESCRIPTION
Wondering if we can get a new version tagged for release purposes (I am in the process of re-sync'ing to master and releasing into ROS2 - Eloquent). 

Looks like there has been some minor api changes since the `1.0.0` tag (e.g. [here](https://github.com/strasdat/Sophus/commit/13fb3288311485dc94e3226b69c9b59cd06ff94e#diff-02290733bf2d979ae4aa077aa9bcc555R101), so I've bumped it to `1.1.0` in this PR.

If this is fine, it could also use a `1.1.0` tag made along with this PR.
