### PR TITLE
Python SE(2) implementation: avoid divide-by-zeros

### DIFF
--- a/py/sophus/__init__.py
+++ b/py/sophus/__init__.py
@@ -4,4 +4,5 @@ from sophus.complex import Complex
 from sophus.quaternion import Quaternion
 from sophus.so2 import So2
 from sophus.so3 import So3
+from sophus.se2 import Se2
 from sophus.se3 import Se3


### PR DESCRIPTION
* Fix 'se2' module not being imported in __init__.py