### PR TITLE
Separated FormatString from common.hpp for embedded use

### DIFF
--- a/sophus/common.hpp
+++ b/sophus/common.hpp
@@ -7,11 +7,14 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <iostream>
 #include <random>
 #include <type_traits>
 
 #include <Eigen/Core>
+
+#if !defined(SOPHUS_DISABLE_ENSURES)
+#include "formatstring.hpp"
+#endif //!defined(SOPHUS_DISABLE_ENSURES)
 
 // following boost's assert.hpp
 #undef SOPHUS_ENSURE
@@ -35,68 +38,6 @@
 #endif
 
 #define SOPHUS_FUNC EIGEN_DEVICE_FUNC
-
-namespace Sophus {
-namespace details {
-
-// Following: http://stackoverflow.com/a/22759544
-template <class T>
-class IsStreamable {
- private:
-  template <class TT>
-  static auto test(int)
-      -> decltype(std::declval<std::stringstream&>() << std::declval<TT>(),
-                  std::true_type());
-
-  template <class>
-  static auto test(...) -> std::false_type;
-
- public:
-  static bool const value = decltype(test<T>(0))::value;
-};
-
-template <class T>
-class ArgToStream {
- public:
-  static void impl(std::stringstream& stream, T&& arg) {
-    stream << std::forward<T>(arg);
-  }
-};
-
-inline void FormatStream(std::stringstream& stream, char const* text) {
-  stream << text;
-  return;
-}
-
-// Following: http://en.cppreference.com/w/cpp/language/parameter_pack
-template <class T, typename... Args>
-void FormatStream(std::stringstream& stream, char const* text, T&& arg,
-                  Args&&... args) {
-  static_assert(IsStreamable<T>::value,
-                "One of the args has no ostream overload!");
-  for (; *text != '\0'; ++text) {
-    if (*text == '%') {
-      ArgToStream<T&&>::impl(stream, std::forward<T>(arg));
-      FormatStream(stream, text + 1, std::forward<Args>(args)...);
-      return;
-    }
-    stream << *text;
-  }
-  stream << "\nFormat-Warning: There are " << sizeof...(Args) + 1
-         << " args unused.";
-  return;
-}
-
-template <class... Args>
-std::string FormatString(char const* text, Args&&... args) {
-  std::stringstream stream;
-  FormatStream(stream, text, std::forward<Args>(args)...);
-  return stream.str();
-}
-
-inline std::string FormatString() { return std::string(); }
-}  // namespace details
-}  // namespace Sophus
 
 #if defined(SOPHUS_DISABLE_ENSURES)
 

--- a/sophus/formatstring.hpp
+++ b/sophus/formatstring.hpp
@@ -1,0 +1,64 @@
+#include <iostream>
+
+namespace Sophus {
+namespace details {
+
+// Following: http://stackoverflow.com/a/22759544
+template <class T>
+class IsStreamable {
+ private:
+  template <class TT>
+  static auto test(int)
+      -> decltype(std::declval<std::stringstream&>() << std::declval<TT>(),
+                  std::true_type());
+
+  template <class>
+  static auto test(...) -> std::false_type;
+
+ public:
+  static bool const value = decltype(test<T>(0))::value;
+};
+
+template <class T>
+class ArgToStream {
+ public:
+  static void impl(std::stringstream& stream, T&& arg) {
+    stream << std::forward<T>(arg);
+  }
+};
+
+inline void FormatStream(std::stringstream& stream, char const* text) {
+  stream << text;
+  return;
+}
+
+// Following: http://en.cppreference.com/w/cpp/language/parameter_pack
+template <class T, typename... Args>
+void FormatStream(std::stringstream& stream, char const* text, T&& arg,
+                  Args&&... args) {
+  static_assert(IsStreamable<T>::value,
+                "One of the args has no ostream overload!");
+  for (; *text != '\0'; ++text) {
+    if (*text == '%') {
+      ArgToStream<T&&>::impl(stream, std::forward<T>(arg));
+      FormatStream(stream, text + 1, std::forward<Args>(args)...);
+      return;
+    }
+    stream << *text;
+  }
+  stream << "\nFormat-Warning: There are " << sizeof...(Args) + 1
+         << " args unused.";
+  return;
+}
+
+template <class... Args>
+std::string FormatString(char const* text, Args&&... args) {
+  std::stringstream stream;
+  FormatStream(stream, text, std::forward<Args>(args)...);
+  return stream.str();
+}
+
+inline std::string FormatString() { return std::string(); }
+
+}  // namespace details
+}  // namespace Sophus

--- a/sophus/formatstring.hpp
+++ b/sophus/formatstring.hpp
@@ -1,3 +1,9 @@
+/// @file
+/// FormatString functionality
+
+#ifndef SOPHUS_FORMATSTRING_HPP
+#define SOPHUS_FORMATSTRING_HPP
+
 #include <iostream>
 
 namespace Sophus {
@@ -62,3 +68,5 @@ inline std::string FormatString() { return std::string(); }
 
 }  // namespace details
 }  // namespace Sophus
+
+#endif //SOPHUS_FORMATSTRING_HPP

--- a/sophus/test_macros.hpp
+++ b/sophus/test_macros.hpp
@@ -2,6 +2,7 @@
 #define SOPUHS_TESTS_MACROS_HPP
 
 #include <sophus/types.hpp>
+#include <sophus/formatstring.hpp>
 
 namespace Sophus {
 namespace details {

--- a/test/core/test_common.cpp
+++ b/test/core/test_common.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 
 #include <sophus/test_macros.hpp>
+#include <sophus/formatstring.hpp>
 
 namespace Sophus {
 


### PR DESCRIPTION
This library is being used for embedded applications and as such, iostream is being removed from the build. To accomplish this when building with SOPHUS_DISABLE_ENSURES, the FormatString functionality needed to be moved to a separate file and conditionally included in common.hpp.