### PR TITLE
Fix Taylor expansion of SO3::logAndTheta

### DIFF
--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -269,7 +269,7 @@ class SO3Base {
                     unit_quaternion().coeffs().transpose());
       Scalar squared_w = w * w;
       two_atan_nbyw_by_n =
-          Scalar(2) / w - Scalar(2) * (squared_n) / (w * squared_w);
+          Scalar(2) / w - Scalar(2.0/3.0) * (squared_n) / (w * squared_w);
       J.theta = Scalar(2) * squared_n / w;
     } else {
       Scalar n = sqrt(squared_n);


### PR DESCRIPTION
Seems to be a typo, see https://www.wolframalpha.com/input/?i=series+2+*+atan%28x+%2F+w%29+%2F+x

Presumably has little practical impact though.

References:
 * https://github.com/strasdat/Sophus/pull/230#discussion_r326546818
 * https://github.com/strasdat/Sophus/issues/186#issuecomment-447566191