### PR TITLE
Fix compilation with -Werror=pedantic

### DIFF
--- a/sophus/rxso2.hpp
+++ b/sophus/rxso2.hpp
@@ -601,7 +601,7 @@ class Map<Sophus::RxSO2<Scalar_>, Options>
   friend class Sophus::RxSO2Base<Map<Sophus::RxSO2<Scalar_>, Options>>;
 
   // LCOV_EXCL_START
-  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map)
   // LCOV_EXCL_STOP
   using Base::operator*=;
   using Base::operator*;

--- a/sophus/rxso3.hpp
+++ b/sophus/rxso3.hpp
@@ -670,7 +670,7 @@ class Map<Sophus::RxSO3<Scalar_>, Options>
   friend class Sophus::RxSO3Base<Map<Sophus::RxSO3<Scalar_>, Options>>;
 
   // LCOV_EXCL_START
-  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map)
   // LCOV_EXCL_STOP
 
   using Base::operator*=;

--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -758,7 +758,7 @@ class Map<Sophus::SE2<Scalar_>, Options>
   using Adjoint = typename Base::Adjoint;
 
   // LCOV_EXCL_START
-  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map)
   // LCOV_EXCL_STOP
 
   using Base::operator*=;

--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -1000,7 +1000,7 @@ class Map<Sophus::SE3<Scalar_>, Options>
   using Adjoint = typename Base::Adjoint;
 
   // LCOV_EXCL_START
-  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map)
   // LCOV_EXCL_STOP
 
   using Base::operator*=;

--- a/sophus/sim2.hpp
+++ b/sophus/sim2.hpp
@@ -647,7 +647,7 @@ class Map<Sophus::Sim2<Scalar_>, Options>
   using Adjoint = typename Base::Adjoint;
 
   // LCOV_EXCL_START
-  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map)
   // LCOV_EXCL_STOP
 
   using Base::operator*=;

--- a/sophus/sim3.hpp
+++ b/sophus/sim3.hpp
@@ -664,7 +664,7 @@ class Map<Sophus::Sim3<Scalar_>, Options>
   using Adjoint = typename Base::Adjoint;
 
   // LCOV_EXCL_START
-  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map)
   // LCOV_EXCL_STOP
 
   using Base::operator*=;

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -561,7 +561,7 @@ class Map<Sophus::SO2<Scalar_>, Options>
   friend class Sophus::SO2Base<Map<Sophus::SO2<Scalar_>, Options>>;
 
   // LCOV_EXCL_START
-  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map)
   // LCOV_EXCL_STOP
 
   using Base::operator*=;

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -791,7 +791,7 @@ class Map<Sophus::SO3<Scalar_>, Options>
   friend class Sophus::SO3Base<Map<Sophus::SO3<Scalar_>, Options>>;
 
   // LCOV_EXCL_START
-  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map)
   // LCOV_EXCL_STOP
 
   using Base::operator*=;


### PR DESCRIPTION
Removes the redundant semi-colons added to calls of SOPHUS_INHERIT_ASSIGNMENT_OPERATORS.