### PR TITLE
RxSO2 and RxSO3 normalization

### DIFF
--- a/sophus/common.hpp
+++ b/sophus/common.hpp
@@ -93,6 +93,8 @@ template <class Scalar>
 struct Constants {
   SOPHUS_FUNC static Scalar epsilon() { return Scalar(1e-10); }
 
+  SOPHUS_FUNC static Scalar epsilonPlus() { return epsilon() * (Scalar(1.) + epsilon()); }
+
   SOPHUS_FUNC static Scalar epsilonSqrt() {
     using std::sqrt;
     return sqrt(epsilon());
@@ -108,6 +110,7 @@ struct Constants<float> {
   SOPHUS_FUNC static float constexpr epsilon() {
     return static_cast<float>(1e-5);
   }
+  SOPHUS_FUNC static float epsilonPlus() { return epsilon() * (1.f + epsilon()); }
 
   SOPHUS_FUNC static float epsilonSqrt() { return std::sqrt(epsilon()); }
 

--- a/sophus/rxso3.hpp
+++ b/sophus/rxso3.hpp
@@ -59,9 +59,10 @@ namespace Sophus {
 /// freedom (DoF) of RxSO3 (=4) equals the number of internal parameters (=4).
 ///
 /// This class has the explicit class invariant that the scale ``s`` is not
-/// too close to zero. Strictly speaking, it must hold that:
+/// too close to either zero or infinity. Strictly speaking, it must hold that:
 ///
-///   ``quaternion().squaredNorm() >= Constants::epsilon()``.
+///   ``quaternion().squaredNorm() >= Constants::epsilon()`` and
+///   ``1. / quaternion().squaredNorm() >= Constants::epsilon()``.
 ///
 /// In order to obey this condition, group multiplication is implemented with
 /// saturation such that a product always has a scale which is equal or greater
@@ -237,6 +238,7 @@ class RxSO3Base {
   template <typename OtherDerived>
   SOPHUS_FUNC RxSO3Product<OtherDerived> operator*(
       RxSO3Base<OtherDerived> const& other) const {
+    using std::sqrt;
     using ResultT = ReturnScalar<OtherDerived>;
     typename RxSO3Product<OtherDerived>::QuaternionType result_quaternion(
         quaternion() * other.quaternion());
@@ -246,7 +248,11 @@ class RxSO3Base {
       SOPHUS_ENSURE(scale > ResultT(0), "Scale must be greater zero.");
       /// Saturation to ensure class invariant.
       result_quaternion.normalize();
-      result_quaternion.coeffs() *= sqrt(Constants<Scalar>::epsilon());
+      result_quaternion.coeffs() *= sqrt(Constants<ResultT>::epsilonPlus());
+    }
+    if (scale > ResultT(1.) / Constants<ResultT>::epsilon()) {
+      result_quaternion.normalize();
+      result_quaternion.coeffs() /= sqrt(Constants<ResultT>::epsilonPlus());
     }
     return RxSO3Product<OtherDerived>(result_quaternion);
   }
@@ -322,11 +328,15 @@ class RxSO3Base {
 
   /// Sets non-zero quaternion
   ///
-  /// Precondition: ``quat`` must not be close to zero.
+  /// Precondition: ``quat`` must not be close to either zero or infinity
   SOPHUS_FUNC void setQuaternion(Eigen::Quaternion<Scalar> const& quat) {
     SOPHUS_ENSURE(quat.squaredNorm() > Constants<Scalar>::epsilon() *
                                            Constants<Scalar>::epsilon(),
                   "Scale factor must be greater-equal epsilon.");
+    SOPHUS_ENSURE(
+        quat.squaredNorm() < Scalar(1.) / (Constants<Scalar>::epsilon() *
+                                           Constants<Scalar>::epsilon()),
+        "Inverse scale factor must be greater-equal epsilon.");
     static_cast<Derived*>(this)->quaternion_nonconst() = quat;
   }
 
@@ -383,6 +393,9 @@ class RxSO3Base {
     SOPHUS_ENSURE(squared_scale >= Constants<Scalar>::epsilon() *
                                        Constants<Scalar>::epsilon(),
                   "Scale factor must be greater-equal epsilon.");
+    SOPHUS_ENSURE(squared_scale < Scalar(1.) / (Constants<Scalar>::epsilon() *
+                                                Constants<Scalar>::epsilon()),
+                  "Inverse scale factor must be greater-equal epsilon.");
     Scalar scale = sqrt(squared_scale);
     quaternion_nonconst() = sR / scale;
     quaternion_nonconst().coeffs() *= sqrt(scale);
@@ -455,31 +468,35 @@ class RxSO3 : public RxSO3Base<RxSO3<Scalar_, Options>> {
   /// Constructor from scale factor and rotation matrix ``R``.
   ///
   /// Precondition: Rotation matrix ``R`` must to be orthogonal with determinant
-  ///               of 1 and ``scale`` must not be close to zero.
+  ///               of 1 and ``scale`` must not be close to either zero or infinity.
   ///
   SOPHUS_FUNC RxSO3(Scalar const& scale, Transformation const& R)
       : quaternion_(R) {
     SOPHUS_ENSURE(scale >= Constants<Scalar>::epsilon(),
                   "Scale factor must be greater-equal epsilon.");
+    SOPHUS_ENSURE(scale < Scalar(1.) / Constants<Scalar>::epsilon(),
+                  "Inverse scale factor must be greater-equal epsilon.");
     using std::sqrt;
     quaternion_.coeffs() *= sqrt(scale);
   }
 
   /// Constructor from scale factor and SO3
   ///
-  /// Precondition: ``scale`` must not to be close to zero.
+  /// Precondition: ``scale`` must not to be close to either zero or infinity.
   ///
   SOPHUS_FUNC RxSO3(Scalar const& scale, SO3<Scalar> const& so3)
       : quaternion_(so3.unit_quaternion()) {
     SOPHUS_ENSURE(scale >= Constants<Scalar>::epsilon(),
                   "Scale factor must be greater-equal epsilon.");
+    SOPHUS_ENSURE(scale < Scalar(1.) / Constants<Scalar>::epsilon(),
+                  "Inverse scale factor must be greater-equal epsilon.");
     using std::sqrt;
     quaternion_.coeffs() *= sqrt(scale);
   }
 
   /// Constructor from quaternion
   ///
-  /// Precondition: quaternion must not be close to zero.
+  /// Precondition: quaternion must not be close to either zero or infinity.
   ///
   template <class D>
   SOPHUS_FUNC explicit RxSO3(Eigen::QuaternionBase<D> const& quat)
@@ -488,6 +505,9 @@ class RxSO3 : public RxSO3Base<RxSO3<Scalar_, Options>> {
                   "must be same Scalar type.");
     SOPHUS_ENSURE(quaternion_.squaredNorm() >= Constants<Scalar>::epsilon(),
                   "Scale factor must be greater-equal epsilon.");
+    SOPHUS_ENSURE(
+        quat.squaredNorm() < Scalar(1.) / Constants<Scalar>::epsilon(),
+        "Inverse scale factor must be greater-equal epsilon.");
   }
 
   /// Accessor of quaternion.
@@ -523,10 +543,16 @@ class RxSO3 : public RxSO3Base<RxSO3<Scalar_, Options>> {
     SOPHUS_ENSURE(theta != nullptr, "must not be nullptr.");
     using std::exp;
     using std::sqrt;
+    using std::max;
+    using std::min;
 
     Vector3<Scalar> const omega = a.template head<3>();
     Scalar sigma = a[3];
-    Scalar sqrt_scale = sqrt(exp(sigma));
+    Scalar scale = exp(sigma);
+    // Ensure that scale-factor contraint is always valid
+    scale = max(scale, Constants<Scalar>::epsilonPlus());
+    scale = min(scale, Scalar(1.) / Constants<Scalar>::epsilonPlus());
+    Scalar sqrt_scale = sqrt(scale);
     Eigen::Quaternion<Scalar> quat =
         SO3<Scalar>::expAndTheta(omega, theta).unit_quaternion();
     quat.coeffs() *= sqrt_scale;


### PR DESCRIPTION
I would like to discuss a problem with `RxSO2` and `RxSO3` normalization/saturation.

With the previous  implementation user might get assertions from "unlucky" multiplication of group elements.

# Problems with "underflow"

## RxSO2

In case of `RxSO2` a squared norm of complex number is compared with squared epsilon and, if comparison fails, complex number is normalized and multiplied by epsilon.

However, one might note that in IEEE754-2008 arithmetic the action taken does not guarantee that the condition is now satisfied.

One particular example (keep in mind that it is not "specifically crafted", one can get many such examples just by sampling random vectors and checking the condition):
```
Epsilon: 1.0000000000000000e-10 ( bb bd d7 d9 df 7c db 3d )
Epsilon^2: 1.0000000000000001e-20 ( 24 42 92 0c a1 9c c7 3b )
Normalized vector: -1.7275509251940485e-01  9.8496481054330653e-01 ( 5a 4d 4b c0 d6 1c c6 bf , 9d d1 1f ec d4 84 ef 3f )
Multiplied by epsilon: -1.7275509251940486e-11  9.8496481054330657e-11 ( 43 de e9 a1 9f fe b2 bd , df e4 8a dc 12 13 db 3d )
Squared norm: 9.9999999999999995e-21 ( 23 42 92 0c a1 9c c7 3b )
```

I suggest to tackle this problem by multiplying normalized vector by a scalar "slightly larger" than `Constants::epsilon`, for example -- `Constants::epsilon*(1. + Constants::epsilon)`

## RxSO3

In case of `RxSO3` squared norm of quaternion is compared with epsilon and, if comparison fails, quaternion is normalized and multiplied by sqrt(epsilon).

As in the case of `RxSO2`, the action taken does not guarantee that the condition is satisfied

I suggest to tackle this problem by multiplying normalized quaternion by a square root of scalar "slightly larger" than epsilon.


# Problems with "overflow"

While "underflow" is handled, "overflow" is not. However, this might result into unwanted consequences, for example:

## RxSO2

* User calls `RxSO2::exp` with a scalar sigma being large enough to `std::exp(w)` being infinite (note that `Vector2::squaredNorm() = inf > epsilon * epsilon` and assertion in constructor does not fires)
* User multiplies the result by some group element s.t. `inf - inf` situation occurs
* Now squared norm is nan and, hence, comparison `squared_scale < epsilon * epsilon` is false (in `operator*`), but `squaredNorm() > epsilon * epsilon` in constructor is also false, which fires an assertion

I suggest to tackle this problem by ensuring that the norm of complex number is small enough, for example - smaller than `1. / epsilon+` (if we just test for "smaller than `1/epsilon`", the same problem that was described in "underflow" case will occur).

## RxSO3

The same situation (call `RxSO3::exp(...)` with a large enough scale, then call `RxSO3::operator*` with a second group element suitable for producing `nan` => get an assertion in result constructor (with somewhat misleading description).
