### PR TITLE
Complete update to Ceres 2.0 and fix unit tests with Jet

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,5 @@
 # Tests to run
 SET( EXAMPLE_SOURCES HelloSO3)
-find_package( Ceres 1.6.0 QUIET )
 
 FOREACH(example_src ${EXAMPLE_SOURCES})
   ADD_EXECUTABLE( ${example_src} ${example_src}.cpp)

--- a/test/ceres/CMakeLists.txt
+++ b/test/ceres/CMakeLists.txt
@@ -12,8 +12,7 @@ if( Ceres_FOUND )
 
   FOREACH(test_src ${TEST_SOURCES})
     ADD_EXECUTABLE( ${test_src} ${test_src}.cpp local_parameterization_se3)
-    TARGET_LINK_LIBRARIES( ${test_src} sophus ${CERES_LIBRARIES} )
-    TARGET_INCLUDE_DIRECTORIES( ${test_src} SYSTEM PRIVATE ${CERES_INCLUDE_DIRS})
+    TARGET_LINK_LIBRARIES( ${test_src} sophus Ceres::ceres )
     ADD_TEST( ${test_src} ${test_src} )
   ENDFOREACH(test_src)
 

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -1,12 +1,12 @@
 # Tests to run
 SET( TEST_SOURCES test_common test_so2 test_se2 test_rxso2 test_sim2 test_so3 test_se3 test_rxso3 test_sim3 test_velocities test_geometry)
-find_package( Ceres 1.6.0 QUIET )
+find_package( Ceres 2.0.0 QUIET )
 
 FOREACH(test_src ${TEST_SOURCES})
   ADD_EXECUTABLE( ${test_src} ${test_src}.cpp tests.hpp ../../sophus/test_macros.hpp)
   TARGET_LINK_LIBRARIES( ${test_src} sophus )
   if( Ceres_FOUND )
-      TARGET_INCLUDE_DIRECTORIES( ${test_src} SYSTEM PRIVATE ${CERES_INCLUDE_DIRS})
+      TARGET_LINK_LIBRARIES( ${test_src} Ceres::ceres )
       ADD_DEFINITIONS(-DSOPHUS_CERES)
   endif(Ceres_FOUND)
   ADD_TEST( ${test_src} ${test_src} )

--- a/test/core/test_rxso2.cpp
+++ b/test/core/test_rxso2.cpp
@@ -128,15 +128,16 @@ class Tests {
     const RxSO2Type large = RxSO2Type::exp(large_log);
     const RxSO2Type regular = RxSO2Type::exp(regular_log);
     const RxSO2Type product = regular * large;
-    SOPHUS_TEST(passed, std::isfinite(large.scale()));
-    SOPHUS_TEST(passed, std::isfinite(product.scale()));
+    SOPHUS_TEST(passed, isfinite(large.scale()));
+    SOPHUS_TEST(passed, isfinite(product.scale()));
 
     // Test if saturation is handled correctly with imprecision of IEEE754-2008
     std::mt19937 rng;
-    std::uniform_real_distribution<Scalar> uniform(Scalar(0.), kPi);
+    std::uniform_real_distribution<double> uniform(0., Constants<double>::pi());
     Tangent small_log;
     while (true) {
-      const Scalar phi = uniform(rng);
+      // Note: sample double and convert to Scalar for compatibility with ceres::Jet
+      const Scalar phi = Scalar(uniform(rng));
       const Scalar c = cos(phi);
       const Scalar s = sin(phi);
       if (c * c + s * s < Scalar(1.)) {

--- a/test/core/test_rxso3.cpp
+++ b/test/core/test_rxso3.cpp
@@ -118,13 +118,14 @@ class Tests {
     const RxSO3Type large = RxSO3Type::exp(large_log);
     const RxSO3Type regular = RxSO3Type::exp(regular_log);
     const RxSO3Type product = regular * large;
-    SOPHUS_TEST(passed, std::isfinite(large.scale()));
-    SOPHUS_TEST(passed, std::isfinite(product.scale()));
+    SOPHUS_TEST(passed, isfinite(large.scale()));
+    SOPHUS_TEST(passed, isfinite(product.scale()));
 
     // Test if saturation is handled correctly with imprecision of IEEE754-2008
     Tangent small_log;
     while (true) {
-      const typename SO3Type::Tangent so3_tangent = SO3Type::Tangent::Random();
+      // Note: use cast() since Random() doesn't work with ceres::Jet Scalar types
+      const typename SO3Type::Tangent so3_tangent = Eigen::Vector3d::Random().cast<Scalar>();
       const SO3Type so3_exp = SO3Type::exp(so3_tangent);
       if (so3_exp.unit_quaternion().squaredNorm() >= Scalar(1.)) continue;
       small_log << so3_tangent, log(Constants<Scalar>::epsilon() / Scalar(2.));

--- a/test/core/tests.hpp
+++ b/test/core/tests.hpp
@@ -17,6 +17,13 @@
 
 namespace Sophus {
 
+// compatibility with ceres::Jet types
+#if SOPHUS_CERES
+using ceres::isfinite;
+#else
+using std::isfinite;
+#endif
+
 template <class LieGroup_>
 class LieGroupTests {
  public:


### PR DESCRIPTION
- Complete the change to Ceres 2.0 (see #270); note that the cmake usage of ceres has changed: http://ceres-solver.org/installation.html#version-2-0
- Fix unit test compilation when compiling with ceres (see #267). I tested unit test w/ and w/o ceres.