### PR TITLE
simplify SO2 normalize

### DIFF
--- a/sophus/rxso2.hpp
+++ b/sophus/rxso2.hpp
@@ -155,8 +155,8 @@ class RxSO2Base {
   ///
   SOPHUS_FUNC RxSO2<Scalar> inverse() const {
     Scalar squared_scale = complex().squaredNorm();
-    return RxSO2<Scalar>(complex().x() / squared_scale,
-                         -complex().y() / squared_scale);
+    Vector2<Scalar> xy = complex() / squared_scale;
+    return RxSO2<Scalar>(xy.x(), -xy.y());
   }
 
   /// Logarithmic map
@@ -354,8 +354,10 @@ class RxSO2Base {
 
   /// Returns scale.
   ///
-  SOPHUS_FUNC
-  Scalar scale() const { return complex().norm(); }
+  SOPHUS_FUNC Scalar scale() const {
+    using std::hypot;
+    return hypot(complex().x(), complex().y());
+  }
 
   /// Setter of rotation angle, leaves scale as is.
   ///

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -170,13 +170,12 @@ class SO2Base {
   /// this function directly.
   ///
   SOPHUS_FUNC void normalize() {
-    using std::sqrt;
-    Scalar length = sqrt(unit_complex().x() * unit_complex().x() +
-                         unit_complex().y() * unit_complex().y());
+    using std::hypot;
+    // Avoid under/overflows for higher precision
+    Scalar length = hypot(unit_complex().x(), unit_complex().y());
     SOPHUS_ENSURE(length >= Constants<Scalar>::epsilon(),
                   "Complex number should not be close to zero!");
-    unit_complex_nonconst().x() /= length;
-    unit_complex_nonconst().y() /= length;
+    unit_complex_nonconst() /= length;
   }
 
   /// Returns 2x2 matrix representation of the instance.


### PR DESCRIPTION
1. To be consisent with `std::abs(std::complex<>)`, compute the norm in terms of `std::hypot` to avoid numerical inaccuracies.
2. Vectorize the actual normalization.