### PR TITLE
remove unnecessary SO2 include

### DIFF
--- a/sophus/average.hpp
+++ b/sophus/average.hpp
@@ -4,6 +4,8 @@
 #ifndef SOPHUS_AVERAGE_HPP
 #define SOPHUS_AVERAGE_HPP
 
+#include <complex>
+
 #include "common.hpp"
 #include "rxso2.hpp"
 #include "rxso3.hpp"

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -4,7 +4,6 @@
 #ifndef SOPHUS_SO2_HPP
 #define SOPHUS_SO2_HPP
 
-#include <complex>
 #include <type_traits>
 
 // Include only the selective set of Eigen headers that we need.


### PR DESCRIPTION
Sophus uses a 2-D Eigen type to represent complex numbers. Including `<complex>` in `so2.hpp` is therefore unnecessary.