### PR TITLE
Additional derivatives for RxSO(2,3) and Sim(2,3) groups

### DIFF
--- a/sophus/rxso2.hpp
+++ b/sophus/rxso2.hpp
@@ -290,6 +290,15 @@ class RxSO2Base {
     return *this;
   }
 
+  /// Returns derivative of  this * RxSO2::exp(x) wrt. x at x=0
+  ///
+  SOPHUS_FUNC Matrix<Scalar, num_parameters, DoF> Dx_this_mul_exp_x_at_0()
+      const {
+    Matrix<Scalar, num_parameters, DoF> J;
+    J << -complex().y(), complex().x(), complex().x(), complex().y();
+    return J;
+  }
+
   /// Returns internal parameters of RxSO(2).
   ///
   /// It returns (c[0], c[1]), with c being the  complex number.
@@ -398,6 +407,9 @@ class RxSO2 : public RxSO2Base<RxSO2<Scalar_, Options>> {
 
   using Base::operator=;
 
+  static int constexpr DoF = Base::DoF;
+  static int constexpr num_parameters = Base::num_parameters;
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes complex number to identity rotation and
@@ -468,6 +480,32 @@ class RxSO2 : public RxSO2Base<RxSO2<Scalar_, Options>> {
   /// Accessor of complex.
   ///
   SOPHUS_FUNC ComplexMember const& complex() const { return complex_; }
+
+  /// Returns derivative of exp(x) wrt. ``x``
+  ///
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF> Dx_exp_x(
+      Tangent const& a) {
+    using std::cos;
+    using std::exp;
+    using std::sin;
+    Scalar const theta = a[0];
+    Scalar const sigma = a[1];
+
+    Sophus::Matrix<Scalar, num_parameters, DoF> J;
+    J << -sin(theta), cos(theta), cos(theta), sin(theta);
+    return J * exp(sigma);
+  }
+
+  /// Returns derivative of exp(x) wrt. x_i at x=0.
+  ///
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF>
+  Dx_exp_x_at_0() {
+    Sophus::Matrix<Scalar, num_parameters, DoF> J;
+    static Scalar const i(1.);
+    static Scalar const o(0.);
+    J << o, i, i, o;
+    return J;
+  }
 
   /// Returns derivative of exp(x).matrix() wrt. ``x_i at x=0``.
   ///

--- a/sophus/sim2.hpp
+++ b/sophus/sim2.hpp
@@ -274,6 +274,18 @@ class Sim2Base {
     return *this;
   }
 
+  /// Returns derivative of  this * Sim2::exp(x)  wrt. x at x=0.
+  ///
+  SOPHUS_FUNC Matrix<Scalar, num_parameters, DoF> Dx_this_mul_exp_x_at_0()
+      const {
+    Matrix<Scalar, num_parameters, DoF> J;
+    J.template block<2, 2>(0, 0).setZero();
+    J.template block<2, 2>(0, 2) = rxso2().Dx_this_mul_exp_x_at_0();
+    J.template block<2, 2>(2, 2).setZero();
+    J.template block<2, 2>(2, 0) = rxso2().matrix();
+    return J;
+  }
+
   /// Setter of non-zero complex number.
   ///
   /// Precondition: ``z`` must not be close to zero.
@@ -363,6 +375,9 @@ class Sim2 : public Sim2Base<Sim2<Scalar_, Options>> {
 
   using Base::operator=;
 
+  static int constexpr DoF = Base::DoF;
+  static int constexpr num_parameters = Base::num_parameters;
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes similarity transform to the identity.
@@ -448,6 +463,55 @@ class Sim2 : public Sim2Base<Sim2<Scalar_, Options>> {
   ///
   SOPHUS_FUNC TranslationMember const& translation() const {
     return translation_;
+  }
+
+  /// Returns derivative of exp(x) wrt. x_i at x=0.
+  ///
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF>
+  Dx_exp_x_at_0() {
+    Sophus::Matrix<Scalar, num_parameters, DoF> J;
+    J.template block<2, 2>(0, 0).setZero();
+    J.template block<2, 2>(0, 2) = RxSO2<Scalar>::Dx_exp_x_at_0();
+    J.template block<2, 2>(2, 0).setIdentity();
+    J.template block<2, 2>(2, 2).setZero();
+    return J;
+  }
+
+  /// Returns derivative of exp(x) wrt. x.
+  ///
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF> Dx_exp_x(
+      const Tangent& a) {
+    static Matrix2<Scalar> const I = Matrix2<Scalar>::Identity();
+    static Scalar const one(1.0);
+
+    Scalar const theta = a[2];
+    Scalar const sigma = a[3];
+
+    Matrix2<Scalar> const Omega = SO2<Scalar>::hat(theta);
+    Matrix2<Scalar> const Omega_dtheta = SO2<Scalar>::hat(one);
+    Matrix2<Scalar> const Omega2 = Omega * Omega;
+    Matrix2<Scalar> const Omega2_dtheta =
+        Omega_dtheta * Omega + Omega * Omega_dtheta;
+    Matrix2<Scalar> const W = details::calcW<Scalar, 2>(Omega, theta, sigma);
+    Vector2<Scalar> const upsilon = a.segment(0, 2);
+
+    Sophus::Matrix<Scalar, num_parameters, DoF> J;
+    J.template block<2, 2>(0, 0).setZero();
+    J.template block<2, 2>(0, 2) =
+        RxSO2<Scalar>::Dx_exp_x(a.template tail<2>());
+    J.template block<2, 2>(2, 0) = W;
+
+    Scalar A, B, C, A_dtheta, B_dtheta, A_dsigma, B_dsigma, C_dsigma;
+    details::calcW_derivatives(theta, sigma, A, B, C, A_dsigma, B_dsigma,
+                               C_dsigma, A_dtheta, B_dtheta);
+
+    J.template block<2, 1>(2, 2) = (A_dtheta * Omega + A * Omega_dtheta +
+                                    B_dtheta * Omega2 + B * Omega2_dtheta) *
+                                   upsilon;
+    J.template block<2, 1>(2, 3) =
+        (A_dsigma * Omega + B_dsigma * Omega2 + C_dsigma * I) * upsilon;
+
+    return J;
   }
 
   /// Returns derivative of exp(x).matrix() wrt. ``x_i at x=0``.

--- a/sophus/sim_details.hpp
+++ b/sophus/sim_details.hpp
@@ -7,7 +7,7 @@ namespace Sophus {
 namespace details {
 
 template <class Scalar, int N>
-Matrix<Scalar, N, N> calcW(Matrix<Scalar, N, N> const& Omega,
+Matrix<Scalar, N, N> calcW(Matrix<Scalar, N, N> const &Omega,
                            Scalar const theta, Scalar const sigma) {
   using std::abs;
   using std::cos;
@@ -48,8 +48,99 @@ Matrix<Scalar, N, N> calcW(Matrix<Scalar, N, N> const& Omega,
   return A * Omega + B * Omega2 + C * I;
 }
 
+template <class Scalar>
+void calcW_derivatives(Scalar const theta, Scalar const sigma, Scalar &A,
+                       Scalar &B, Scalar &C, Scalar &A_dsigma, Scalar &B_dsigma,
+                       Scalar &C_dsigma, Scalar &A_dtheta, Scalar &B_dtheta) {
+  using std::abs;
+  using std::cos;
+  using std::exp;
+  using std::sin;
+  static Scalar const zero(0.0);
+  static Scalar const one(1.0);
+  static Scalar const half(0.5);
+  static Scalar const two(2.0);
+  static Scalar const three(3.0);
+  Scalar const theta_sq = theta * theta;
+  Scalar const theta_c = theta * theta_sq;
+  Scalar const sin_theta = sin(theta);
+  Scalar const cos_theta = cos(theta);
+
+  Scalar const scale = exp(sigma);
+  Scalar const sigma_sq = sigma * sigma;
+  Scalar const sigma_c = sigma * sigma_sq;
+
+  if (abs(sigma) < Constants<Scalar>::epsilon()) {
+    C = one;
+    C_dsigma = half;
+    if (abs(theta) < Constants<Scalar>::epsilon()) {
+      A = half;
+      B = Scalar(1. / 6.);
+      A_dtheta = A_dsigma = zero;
+      B_dtheta = B_dsigma = zero;
+    } else {
+      A = (one - cos_theta) / theta_sq;
+      B = (theta - sin_theta) / theta_c;
+      A_dtheta = (theta * sin_theta + two * cos_theta - two) / theta_c;
+      B_dtheta = -(two * theta - three * sin_theta + theta * cos_theta) /
+                 (theta_c * theta);
+      A_dsigma = (sin_theta - theta * cos_theta) / theta_c;
+      B_dsigma =
+          (half - (cos_theta + theta * sin_theta - one) / theta_sq) / theta_sq;
+    }
+  } else {
+    C = (scale - one) / sigma;
+    C_dsigma = (scale * (sigma - one) + one) / sigma_sq;
+    if (abs(theta) < Constants<Scalar>::epsilon()) {
+      A = ((sigma - one) * scale + one) / sigma_sq;
+      B = (scale * half * sigma_sq + scale - one - sigma * scale) / sigma_c;
+      A_dsigma = (scale * (sigma_sq - two * sigma + two) - two) / sigma_c;
+      B_dsigma = (scale * (half * sigma_c - (one + half) * sigma_sq +
+                           three * sigma - three) +
+                  three) /
+                 (sigma_c * sigma);
+      A_dtheta = B_dtheta = zero;
+    } else {
+      Scalar const a = scale * sin_theta;
+      Scalar const b = scale * cos_theta;
+      Scalar const b_one = b - one;
+      Scalar const theta_b_one = theta * b_one;
+      Scalar const c = theta_sq + sigma_sq;
+      Scalar const c_sq = c * c;
+      Scalar const theta_sq_c = theta_sq * c;
+      Scalar const a_theta = theta * a;
+      Scalar const b_theta = theta * b;
+      Scalar const c_theta = theta * c;
+      Scalar const a_sigma = sigma * a;
+      Scalar const b_sigma = sigma * b;
+      Scalar const two_sigma = sigma * two;
+      Scalar const two_theta = theta * two;
+      Scalar const sigma_b_one = sigma * b_one;
+
+      A = (a_sigma - theta_b_one) / c_theta;
+      A_dtheta = (two * (theta_b_one - a_sigma)) / c_sq +
+                 (b_sigma - b + a_theta + one) / c_theta +
+                 (theta_b_one - a_sigma) / theta_sq_c;
+      A_dsigma = (a - b_theta + a_sigma) / c_theta -
+                 (two_sigma * (theta - b_theta + a_sigma)) / (theta * c_sq);
+
+      B = (C - (sigma_b_one + a_theta) / (c)) * one / (theta_sq);
+      B_dtheta =
+          ((two_theta * (b_sigma - sigma + a_theta)) / c_sq -
+           ((a + b_theta - a_sigma)) / c) /
+              theta_sq -
+          (two * ((scale - one) / sigma - (b_sigma - sigma + a_theta) / c)) /
+              theta_c;
+      B_dsigma =
+          -((b_sigma + a_theta + b_one) / c + (scale - one) / sigma_sq -
+            (two_sigma * (sigma_b_one + a_theta)) / c_sq - scale / sigma) /
+          theta_sq;
+    }
+  }
+}
+
 template <class Scalar, int N>
-Matrix<Scalar, N, N> calcWInv(Matrix<Scalar, N, N> const& Omega,
+Matrix<Scalar, N, N> calcWInv(Matrix<Scalar, N, N> const &Omega,
                               Scalar const theta, Scalar const sigma,
                               Scalar const scale) {
   using std::abs;

--- a/test/core/tests.hpp
+++ b/test/core/tests.hpp
@@ -139,12 +139,7 @@ class LieGroupTests {
   }
 
   template <class G = LieGroup>
-  enable_if_t<std::is_same<G, Sophus::SO2<Scalar>>::value ||
-                  std::is_same<G, Sophus::SO3<Scalar>>::value ||
-                  std::is_same<G, Sophus::SE2<Scalar>>::value ||
-                  std::is_same<G, Sophus::SE3<Scalar>>::value,
-              bool>
-  additionalDerivativeTest() {
+  bool additionalDerivativeTest() {
     bool passed = true;
     for (size_t j = 0; j < tangent_vec_.size(); ++j) {
       Tangent a = tangent_vec_[j];
@@ -187,16 +182,6 @@ class LieGroupTests {
     }
 
     return passed;
-  }
-
-  template <class G = LieGroup>
-  enable_if_t<!std::is_same<G, Sophus::SO2<Scalar>>::value &&
-                  !std::is_same<G, Sophus::SO3<Scalar>>::value &&
-                  !std::is_same<G, Sophus::SE2<Scalar>>::value &&
-                  !std::is_same<G, Sophus::SE3<Scalar>>::value,
-              bool>
-  additionalDerivativeTest() {
-    return true;
   }
 
   bool productTest() {


### PR DESCRIPTION
This pull-request makes `RxSO2`, `RxSO3`, `Sim2` and `Sim3` groups complete in terms of "additional derivatives" (`Group::Dx_this_mul_exp_x_at_0`, `Group::Dx_exp_x` and `Group::Dx_exp_x_at_0` methods).

Since all groups now have the same set of derivative-evaluation methods, `LieGroupTests::additionalDerivativesTest` is enabled for all groups