### PR TITLE
Add left group action on hyper-planes

### DIFF
--- a/scripts/run_cpp_tests.sh
+++ b/scripts/run_cpp_tests.sh
@@ -7,5 +7,6 @@ mkdir build
 cd build
 pwd
 cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DUSE_BASIC_LOGGING=$USE_BASIC_LOGGING -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
-make -j4
+# Ubuntu builds via Github actions run on 2-core virtual machines
+make -j2
 make CTEST_OUTPUT_ON_FAILURE=1 test

--- a/sophus/rxso2.hpp
+++ b/sophus/rxso2.hpp
@@ -95,6 +95,7 @@ class RxSO2Base {
   using Point = Vector2<Scalar>;
   using HomogeneousPoint = Vector3<Scalar>;
   using Line = ParametrizedLine2<Scalar>;
+  using Hyperplane = Hyperplane2<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
@@ -273,6 +274,23 @@ class RxSO2Base {
   ///
   SOPHUS_FUNC Line operator*(Line const& l) const {
     return Line((*this) * l.origin(), (*this) * l.direction() / scale());
+  }
+
+  /// Group action on hyper-planes.
+  ///
+  /// This function rotates a hyper-plane ``n.x + d = 0`` by the SO2
+  /// element and scales offset by the scale factor
+  ///
+  /// Normal vector ``n`` is rotated
+  /// Offset ``d`` is scaled
+  ///
+  /// Note that in 2d-case hyper-planes are just another parametrization of
+  /// lines
+  ///
+  SOPHUS_FUNC Hyperplane operator*(Hyperplane const& p) const {
+    const auto this_scale = scale();
+    return Hyperplane((*this) * p.normal() / this_scale,
+                      this_scale * p.offset());
   }
 
   /// In-place group multiplication. This method is only valid if the return

--- a/sophus/rxso3.hpp
+++ b/sophus/rxso3.hpp
@@ -87,6 +87,7 @@ class RxSO3Base {
   using Point = Vector3<Scalar>;
   using HomogeneousPoint = Vector4<Scalar>;
   using Line = ParametrizedLine3<Scalar>;
+  using Hyperplane = Hyperplane3<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
@@ -300,6 +301,20 @@ class RxSO3Base {
   SOPHUS_FUNC Line operator*(Line const& l) const {
     return Line((*this) * l.origin(),
                 (*this) * l.direction() / quaternion().squaredNorm());
+  }
+
+  /// Group action on planes.
+  ///
+  /// This function rotates parametrized plane
+  /// ``n.x + d = 0`` by the SO3 element and scales it by the scale factor:
+  ///
+  /// Normal vector ``n`` is rotated
+  /// Offset ``d`` is scaled
+  ///
+  SOPHUS_FUNC Hyperplane operator*(Hyperplane const& p) const {
+    const auto this_scale = scale();
+    return Hyperplane((*this) * p.normal() / this_scale,
+                      this_scale * p.offset());
   }
 
   /// In-place group multiplication. This method is only valid if the return

--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -74,6 +74,7 @@ class SE2Base {
   using Point = Vector2<Scalar>;
   using HomogeneousPoint = Vector3<Scalar>;
   using Line = ParametrizedLine2<Scalar>;
+  using Hyperplane = Hyperplane2<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
@@ -270,6 +271,23 @@ class SE2Base {
   ///
   SOPHUS_FUNC Line operator*(Line const& l) const {
     return Line((*this) * l.origin(), so2() * l.direction());
+  }
+
+  /// Group action on hyper-planes.
+  ///
+  /// This function rotates a hyper-plane ``n.x + d = 0`` by the SE2
+  /// element:
+  ///
+  /// Normal vector ``n`` is rotated
+  /// Offset ``d`` is adjusted for translation
+  ///
+  /// Note that in 2d-case hyper-planes are just another parametrization of
+  /// lines
+  ///
+  SOPHUS_FUNC Hyperplane operator*(Hyperplane const& p) const {
+    Hyperplane const rotated = so2() * p;
+    return Hyperplane(rotated.normal(),
+                      rotated.offset() - translation().dot(rotated.normal()));
   }
 
   /// In-place group multiplication. This method is only valid if the return

--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -74,6 +74,7 @@ class SE3Base {
   using Point = Vector3<Scalar>;
   using HomogeneousPoint = Vector4<Scalar>;
   using Line = ParametrizedLine3<Scalar>;
+  using Hyperplane = Hyperplane3<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
@@ -345,6 +346,20 @@ class SE3Base {
   ///
   SOPHUS_FUNC Line operator*(Line const& l) const {
     return Line((*this) * l.origin(), so3() * l.direction());
+  }
+
+  /// Group action on planes.
+  ///
+  /// This function rotates and translates a plane
+  /// ``n.x + d = 0`` by the SE(3) element:
+  ///
+  /// Normal vector ``n`` is rotated
+  /// Offset ``d`` is adjusted for translation
+  ///
+  SOPHUS_FUNC Hyperplane operator*(Hyperplane const& p) const {
+    Hyperplane const rotated = so3() * p;
+    return Hyperplane(rotated.normal(),
+                      rotated.offset() - translation().dot(rotated.normal()));
   }
 
   /// In-place group multiplication. This method is only valid if the return

--- a/sophus/sim2.hpp
+++ b/sophus/sim2.hpp
@@ -75,6 +75,7 @@ class Sim2Base {
   using Point = Vector2<Scalar>;
   using HomogeneousPoint = Vector3<Scalar>;
   using Line = ParametrizedLine2<Scalar>;
+  using Hyperplane = Hyperplane2<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
@@ -249,6 +250,23 @@ class Sim2Base {
   SOPHUS_FUNC Line operator*(Line const& l) const {
     Line rotatedLine = rxso2() * l;
     return Line(rotatedLine.origin() + translation(), rotatedLine.direction());
+  }
+
+  /// Group action on hyper-planes.
+  ///
+  /// This function rotates a hyper-plane ``n.x + d = 0`` by the Sim2
+  /// element:
+  ///
+  /// Normal vector ``n`` is rotated
+  /// Offset ``d`` is scaled and adjusted for translation
+  ///
+  /// Note that in 2d-case hyper-planes are just another parametrization of
+  /// lines
+  ///
+  SOPHUS_FUNC Hyperplane operator*(Hyperplane const& p) const {
+    Hyperplane const rotated = rxso2() * p;
+    return Hyperplane(rotated.normal(),
+                      rotated.offset() - translation().dot(rotated.normal()));
   }
 
   /// Returns internal parameters of Sim(2).

--- a/sophus/sim3.hpp
+++ b/sophus/sim3.hpp
@@ -76,6 +76,7 @@ class Sim3Base {
   using Point = Vector3<Scalar>;
   using HomogeneousPoint = Vector4<Scalar>;
   using Line = ParametrizedLine3<Scalar>;
+  using Hyperplane = Hyperplane3<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
@@ -251,6 +252,20 @@ class Sim3Base {
   SOPHUS_FUNC Line operator*(Line const& l) const {
     Line rotatedLine = rxso3() * l;
     return Line(rotatedLine.origin() + translation(), rotatedLine.direction());
+  }
+
+  /// Group action on planes.
+  ///
+  /// This function rotates and translates a plane
+  /// ``n.x + d = 0`` by the Sim(3) element:
+  ///
+  /// Normal vector ``n`` is rotated
+  /// Offset ``d`` is adjusted for scale and translation
+  ///
+  SOPHUS_FUNC Hyperplane operator*(Hyperplane const& p) const {
+    Hyperplane const rotated = rxso3() * p;
+    return Hyperplane(rotated.normal(),
+                      rotated.offset() - translation().dot(rotated.normal()));
   }
 
   /// In-place group multiplication. This method is only valid if the return

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -94,6 +94,7 @@ class SO2Base {
   using Point = Vector2<Scalar>;
   using HomogeneousPoint = Vector3<Scalar>;
   using Line = ParametrizedLine2<Scalar>;
+  using Hyperplane = Hyperplane2<Scalar>;
   using Tangent = Scalar;
   using Adjoint = Scalar;
 
@@ -274,6 +275,21 @@ class SO2Base {
   ///
   SOPHUS_FUNC Line operator*(Line const& l) const {
     return Line((*this) * l.origin(), (*this) * l.direction());
+  }
+
+  /// Group action on hyper-planes.
+  ///
+  /// This function rotates a hyper-plane ``n.x + d = 0`` by the SO2
+  /// element:
+  ///
+  /// Normal vector ``n`` is rotated
+  /// Offset ``d`` is left unchanged
+  ///
+  /// Note that in 2d-case hyper-planes are just another parametrization of
+  /// lines
+  ///
+  SOPHUS_FUNC Hyperplane operator*(Hyperplane const& p) const {
+    return Hyperplane((*this) * p.normal(), p.offset());
   }
 
   /// In-place group multiplication. This method is only valid if the return

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -92,6 +92,7 @@ class SO3Base {
   using Point = Vector3<Scalar>;
   using HomogeneousPoint = Vector4<Scalar>;
   using Line = ParametrizedLine3<Scalar>;
+  using Hyperplane = Hyperplane3<Scalar>;
   using Tangent = Vector<Scalar, DoF>;
   using Adjoint = Matrix<Scalar, DoF, DoF>;
 
@@ -386,6 +387,18 @@ class SO3Base {
   ///
   SOPHUS_FUNC Line operator*(Line const& l) const {
     return Line((*this) * l.origin(), (*this) * l.direction());
+  }
+
+  /// Group action on planes.
+  ///
+  /// This function rotates a plane
+  /// ``n.x + d = 0`` by the SO3 element:
+  ///
+  /// Normal vector ``n`` is rotated
+  /// Offset ``d`` is left unchanged
+  ///
+  SOPHUS_FUNC Hyperplane operator*(Hyperplane const& p) const {
+    return Hyperplane((*this) * p.normal(), p.offset());
   }
 
   /// In-place group multiplication. This method is only valid if the return

--- a/sophus/types.hpp
+++ b/sophus/types.hpp
@@ -78,6 +78,19 @@ using ParametrizedLine2 = ParametrizedLine<Scalar, 2, Options>;
 using ParametrizedLine2f = ParametrizedLine2<float>;
 using ParametrizedLine2d = ParametrizedLine2<double>;
 
+template <class Scalar, int N, int Options = 0>
+using Hyperplane = Eigen::Hyperplane<Scalar, N, Options>;
+
+template <class Scalar, int Options = 0>
+using Hyperplane3 = Eigen::Hyperplane<Scalar, 3, Options>;
+using Hyperplane3f = Hyperplane3<float>;
+using Hyperplane3d = Hyperplane3<double>;
+
+template <class Scalar, int Options = 0>
+using Hyperplane2 = Eigen::Hyperplane<Scalar, 2, Options>;
+using Hyperplane2f = Hyperplane2<float>;
+using Hyperplane2d = Hyperplane2<double>;
+
 namespace details {
 template <class Scalar>
 class MaxMetric {

--- a/test/core/test_rxso3.cpp
+++ b/test/core/test_rxso3.cpp
@@ -75,6 +75,7 @@ class Tests {
 
     point_vec_.push_back(Point(Scalar(1), Scalar(2), Scalar(4)));
     point_vec_.push_back(Point(Scalar(1), Scalar(-3), Scalar(0.5)));
+    point_vec_.push_back(Point(Scalar(-5), Scalar(-6), Scalar(7)));
   }
 
   void runAll() {

--- a/test/core/test_se3.cpp
+++ b/test/core/test_se3.cpp
@@ -48,6 +48,7 @@ class Tests {
 
     point_vec_.push_back(Point(Scalar(1), Scalar(2), Scalar(4)));
     point_vec_.push_back(Point(Scalar(1), Scalar(-3), Scalar(0.5)));
+    point_vec_.push_back(Point(Scalar(-5), Scalar(-6), Scalar(7)));
   }
 
   void runAll() {

--- a/test/core/test_sim3.cpp
+++ b/test/core/test_sim3.cpp
@@ -107,6 +107,7 @@ class Tests {
 
     point_vec_.push_back(Point(Scalar(1), Scalar(2), Scalar(4)));
     point_vec_.push_back(Point(Scalar(1), Scalar(-3), Scalar(0.5)));
+    point_vec_.push_back(Point(Scalar(-5), Scalar(-6), Scalar(7)));
   }
 
   void runAll() {

--- a/test/core/test_so3.cpp
+++ b/test/core/test_so3.cpp
@@ -59,6 +59,7 @@ class Tests {
 
     point_vec_.push_back(Point(Scalar(1), Scalar(2), Scalar(4)));
     point_vec_.push_back(Point(Scalar(1), Scalar(-3), Scalar(0.5)));
+    point_vec_.push_back(Point(Scalar(-5), Scalar(-6), Scalar(7)));
   }
 
   void runAll() {


### PR DESCRIPTION
This pull-request adds left group action on hyper-planes (`Eigen::Hyperplane<Scalar, Dim>`); while for groups acting on 2d-space hyper-planes are just another parameterization of lines, 3d-case is more useful.

The norm of normal vector is preserved since it is used as (unenforced) class-invariant in `Eigen` (for computing distance-to-plane, etc).