### PR TITLE
Revisit fixing SO3::log() / logAndTheta() when rotation has angle close to pi

### DIFF
--- a/sophus/interpolate_details.hpp
+++ b/sophus/interpolate_details.hpp
@@ -22,9 +22,9 @@ struct Traits<SO2<Scalar>> {
 
   static bool hasShortestPathAmbiguity(SO2<Scalar> const& foo_T_bar) {
     using std::abs;
-    Scalar angle = foo_T_bar.log();
-    return abs(abs(angle) - Constants<Scalar>::pi()) <
-           Constants<Scalar>::epsilon();
+    Scalar angle = abs(foo_T_bar.log());
+    Scalar const kPi = Constants<Scalar>::pi();
+    return abs(angle - kPi) / (angle + kPi) < Constants<Scalar>::epsilon();
   }
 };
 
@@ -43,9 +43,9 @@ struct Traits<SO3<Scalar>> {
 
   static bool hasShortestPathAmbiguity(SO3<Scalar> const& foo_T_bar) {
     using std::abs;
-    Scalar angle = foo_T_bar.logAndTheta().theta;
-    return abs(abs(angle) - Constants<Scalar>::pi()) <
-           Constants<Scalar>::epsilon();
+    Scalar angle = abs(foo_T_bar.logAndTheta().theta);
+    Scalar const kPi = Constants<Scalar>::pi();
+    return abs(angle - kPi) / (angle + kPi) < Constants<Scalar>::epsilon();
   }
 };
 

--- a/test/ceres/CMakeLists.txt
+++ b/test/ceres/CMakeLists.txt
@@ -8,7 +8,7 @@ if( Ceres_FOUND )
   MESSAGE(STATUS "CERES found")
 
   # Tests to run
-  SET( TEST_SOURCES test_ceres_se3 )
+  SET( TEST_SOURCES test_ceres_se3 test_ceres_so3)
 
   FOREACH(test_src ${TEST_SOURCES})
     ADD_EXECUTABLE( ${test_src} ${test_src}.cpp local_parameterization_se3.hpp)

--- a/test/ceres/test_ceres_so3.cpp
+++ b/test/ceres/test_ceres_so3.cpp
@@ -1,0 +1,94 @@
+#include <ceres/ceres.h>
+#include <iostream>
+#include <sophus/so3.hpp>
+
+struct TestCostFunctor {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  TestCostFunctor(Sophus::SO3d C_aw) : C_aw(C_aw) {}
+
+  template <class T>
+  bool operator()(T const* const sC_wa, T* sResiduals) const {
+    Eigen::Map<Sophus::SO3<T> const> const C_wa(sC_wa);
+    Eigen::Map<Eigen::Matrix<T, 3, 1> > residuals(sResiduals);
+
+    // We are able to mix Sophus types with doubles and Jet types without
+    // needing to cast to T.
+    residuals = (C_aw * C_wa).log();
+    // Reverse order of multiplication. This forces the compiler to verify that
+    // (Jet, double) and (double, Jet) SO3 multiplication work correctly.
+    residuals = (C_wa * C_aw).log();
+    // Finally, ensure that Jet-to-Jet multiplication works.
+    residuals = (C_wa * C_aw.cast<T>()).log();
+    return true;
+  }
+
+  Sophus::SO3d C_aw;
+};
+
+// Checks if ceres optimization will proceed correctly given problematic or
+// close-to-singular initial conditions, i.e. approx. 180-deg rotation, which
+// trips a flaw in old implementation of SO3::log() where the tangent vector's
+// magnitude is set to a constant close to \pi whenever the input rotation's
+// rotation angle is within some tolerance of \pi, giving zero gradients wrt
+// scalar part of quaternion.
+bool test(Sophus::SO3d const& C_w_targ, Sophus::SO3d const& C_w_init) {
+  Sophus::SO3d C_wr = C_w_init;
+  ceres::Problem problem;
+  // Specify local update rule for our parameter.
+  problem.AddParameterBlock(C_wr.data(), Sophus::SO3d::num_parameters,
+                            new ceres::EigenQuaternionParameterization);
+
+  // Create and add cost functions. Derivatives will be evaluated via
+  // automatic differentiation
+  ceres::CostFunction* cosC_function =
+      new ceres::AutoDiffCostFunction<TestCostFunctor, Sophus::SO3d::DoF,
+                                      Sophus::SO3d::num_parameters>(
+          new TestCostFunctor(C_w_targ.inverse()));
+  problem.AddResidualBlock(cosC_function, NULL, C_wr.data());
+
+  // Set solver options (precision / method)
+  ceres::Solver::Options options;
+  options.gradient_tolerance = 0.01 * Sophus::Constants<double>::epsilon();
+  options.function_tolerance = 0.01 * Sophus::Constants<double>::epsilon();
+  options.linear_solver_type = ceres::DENSE_QR;
+
+  ceres::Solver::Summary summary;
+  Solve(options, &problem, &summary);
+  std::cout << summary.BriefReport() << std::endl;
+
+  // Difference between target and parameter
+  double const mse = (C_w_targ.inverse() * C_wr).log().squaredNorm();
+  bool const passed = mse < 10. * Sophus::Constants<double>::epsilon();
+  return passed;
+}
+
+int main(int, char**) {
+  using SO3Type = Sophus::SO3<double>;
+  using Tangent = SO3Type::Tangent;
+  double const kPi = Sophus::Constants<double>::pi();
+  double const epsilon = Sophus::Constants<double>::epsilon();
+
+  SO3Type C_0 = SO3Type::exp(Tangent(0.1, 0.05, -0.7));
+
+  Tangent axis_0(0.18005924, -0.54563405, 0.81845107);
+  auto ics = {C_0 * SO3Type::exp(axis_0 * 1.0),  // Generic rotation angle < pi
+              C_0 * SO3Type::exp(axis_0 * -1.0),
+              C_0 * SO3Type::exp(axis_0 * 4.0),  // Generic rotation angle > pi
+              C_0 * SO3Type::exp(axis_0 * -4.0),
+              C_0 * SO3Type::exp(axis_0 * kPi),  // Singular rotation angle = pi
+              C_0 * SO3Type::exp(axis_0 * -kPi),
+              C_0 * SO3Type::exp(axis_0 * kPi * (1.0 + epsilon)),
+              C_0 * SO3Type::exp(axis_0 * kPi * (1.0 - epsilon)),
+              C_0 * SO3Type::exp(axis_0 * -kPi * (1.0 + epsilon)),
+              C_0 * SO3Type::exp(axis_0 * -kPi * (1.0 - epsilon))};
+  // Now solve problems.
+  for (const auto& it : ics) {
+    bool const passed = test(C_0, it);
+    if (!passed) {
+      std::cerr << "failed!" << std::endl << std::endl;
+      exit(-1);
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
# Overview

PR #281 and #269 attempted to fix the issue that the automatic differentiated gradient of the `SO3::log()` function is incorrect when the `SO3` object represents a rotation by almost `pi`. Since these PRs were never merged, **this issue persists**. 

This PR revisits the problem, adopting an `atan2` implementation of Hertzberg's _atan-based log_ inspired by Ceres's own `ceres::QuaternionToAngleAxis` in `rotation.h`. [Full details with mathematical derivations are provided in this gist](https://gist.github.com/Hs293Go/7a1bb18f639753c05b8e753089629e50)

## Other Changes

- Implemented `test/ceres/test_ceres_so3.cpp` to verify that the autodiff issue is fixed 
- Changed implementation of `hasShortestPathAmbiguity` in `interpolate_details.hpp` to solve an problem also indicated in #269, i.e. `test_so3.cpp` breaks once `SO3::logAndTheta()` is changed, c.f. 

  > With the new implementation, we found the precision issue of average function (using maximal eigenvector) for float-valued SO3 vectors. So we commented out the tests comparing average vectors from average function against interpolate and iaverage functions... *until end of paragraph*
  
  Instead of commenting out the tests, the issue is pinpointed at `hasShortestPathAmbiguity`, where `logAndTheta().theta` is compared to `pi` by an [absolute error margin, which is too tight (and inherently inappropriate)](https://floating-point-gui.de/errors/comparison/), leading to cases of shortest path ambiguity not being skipped and breaking tests
