### PR TITLE
Add #define FMT_HEADER_ONLY to common.hpp to avoid adding fmt again for other projects depending on Sophus.

### DIFF
--- a/sophus/common.hpp
+++ b/sophus/common.hpp
@@ -38,7 +38,7 @@
 // enable compile time FMT feature
 #define FMT_STRING_ALIAS 1
 #endif
-
+#define FMT_HEADER_ONLY
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/ostream.h>


### PR DESCRIPTION
While building other projects relying on the Sophus, I sometimes witness these errors (even after eliminating the fmt dependency by passing "-DUSE_BASIC_LOGGING=ON").
Adding this line can use fmt in header-only mode to avoid this.