### PR TITLE
Fix compilation with clang-13 by explicitly defining copy-assignment

### DIFF
--- a/sophus/rxso2.hpp
+++ b/sophus/rxso2.hpp
@@ -425,6 +425,11 @@ class RxSO2 : public RxSO2Base<RxSO2<Scalar_, Options>> {
 
   using Base::operator=;
 
+  /// Define copy-assignment operator explicitly. The definition of
+  /// implicit copy assignment operator is deprecated in presence of a
+  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
+  SOPHUS_FUNC RxSO2& operator=(RxSO2 const& other) = default;
+
   static int constexpr DoF = Base::DoF;
   static int constexpr num_parameters = Base::num_parameters;
 

--- a/sophus/rxso3.hpp
+++ b/sophus/rxso3.hpp
@@ -485,6 +485,11 @@ class RxSO3 : public RxSO3Base<RxSO3<Scalar_, Options>> {
 
   using Base::operator=;
 
+  /// Define copy-assignment operator explicitly. The definition of
+  /// implicit copy assignment operator is deprecated in presence of a
+  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
+  SOPHUS_FUNC RxSO3& operator=(RxSO3 const& other) = default;
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes quaternion to identity rotation and scale

--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -393,6 +393,11 @@ class SE2 : public SE2Base<SE2<Scalar_, Options>> {
 
   using Base::operator=;
 
+  /// Define copy-assignment operator explicitly. The definition of
+  /// implicit copy assignment operator is deprecated in presence of a
+  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
+  SOPHUS_FUNC SE2& operator=(SE2 const& other) = default;
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes rigid body motion to the identity.

--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -456,6 +456,11 @@ class SE3 : public SE3Base<SE3<Scalar_, Options>> {
 
   using Base::operator=;
 
+  /// Define copy-assignment operator explicitly. The definition of
+  /// implicit copy assignment operator is deprecated in presence of a
+  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
+  SOPHUS_FUNC SE3& operator=(SE3 const& other) = default;
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes rigid body motion to the identity.

--- a/sophus/sim2.hpp
+++ b/sophus/sim2.hpp
@@ -393,6 +393,11 @@ class Sim2 : public Sim2Base<Sim2<Scalar_, Options>> {
 
   using Base::operator=;
 
+  /// Define copy-assignment operator explicitly. The definition of
+  /// implicit copy assignment operator is deprecated in presence of a
+  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
+  SOPHUS_FUNC Sim2& operator=(Sim2 const& other) = default;
+
   static int constexpr DoF = Base::DoF;
   static int constexpr num_parameters = Base::num_parameters;
 

--- a/sophus/sim3.hpp
+++ b/sophus/sim3.hpp
@@ -394,6 +394,11 @@ class Sim3 : public Sim3Base<Sim3<Scalar_, Options>> {
 
   using Base::operator=;
 
+  /// Define copy-assignment operator explicitly. The definition of
+  /// implicit copy assignment operator is deprecated in presence of a
+  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
+  SOPHUS_FUNC Sim3& operator=(Sim3 const& other) = default;
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes similarity transform to the identity.

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -366,6 +366,11 @@ class SO2 : public SO2Base<SO2<Scalar_, Options>> {
 
   using Base::operator=;
 
+  /// Define copy-assignment operator explicitly. The definition of
+  /// implicit copy assignment operator is deprecated in presence of a
+  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
+  SOPHUS_FUNC SO2& operator=(SO2 const& other) = default;
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes unit complex number to identity rotation.

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -460,6 +460,11 @@ class SO3 : public SO3Base<SO3<Scalar_, Options>> {
 
   using Base::operator=;
 
+  /// Define copy-assignment operator explicitly. The definition of
+  /// implicit copy assignment operator is deprecated in presence of a
+  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
+  SOPHUS_FUNC SO3& operator=(SO3 const& other) = default;
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes unit quaternion to identity rotation.


### PR DESCRIPTION
- Define copy-assignment operator explicitly. The definition of
  implicit copy assignment operator is deprecated in presence of a
  user-declared copy constructor (-Wdeprecated-copy in clang >= 13)
- Building with clang-13 fails without this fix (b/c of Werror)
- On macOS, clang from Homebrew is now version 13.
- Explicitly declaring and defaulting should not change the behaviour,
  just avoid the deprecation.

Fixes #317