### PR TITLE
Make Eigen::Map constructors explicit.

### DIFF
--- a/sophus/rxso2.hpp
+++ b/sophus/rxso2.hpp
@@ -680,7 +680,7 @@ class Map<Sophus::RxSO2<Scalar_>, Options>
   using Base::operator*=;
   using Base::operator*;
 
-  SOPHUS_FUNC Map(Scalar* coeffs) : complex_(coeffs) {}
+  SOPHUS_FUNC explicit Map(Scalar* coeffs) : complex_(coeffs) {}
 
   /// Accessor of complex.
   ///
@@ -717,7 +717,7 @@ class Map<Sophus::RxSO2<Scalar_> const, Options>
   using Base::operator*;
 
   SOPHUS_FUNC
-  Map(Scalar const* coeffs) : complex_(coeffs) {}
+  explicit Map(Scalar const* coeffs) : complex_(coeffs) {}
 
   /// Accessor of complex.
   ///

--- a/sophus/rxso3.hpp
+++ b/sophus/rxso3.hpp
@@ -771,7 +771,7 @@ class Map<Sophus::RxSO3<Scalar_>, Options>
   using Base::operator*=;
   using Base::operator*;
 
-  SOPHUS_FUNC Map(Scalar* coeffs) : quaternion_(coeffs) {}
+  SOPHUS_FUNC explicit Map(Scalar* coeffs) : quaternion_(coeffs) {}
 
   /// Accessor of quaternion.
   ///
@@ -808,7 +808,7 @@ class Map<Sophus::RxSO3<Scalar_> const, Options>
   using Base::operator*;
 
   SOPHUS_FUNC
-  Map(Scalar const* coeffs) : quaternion_(coeffs) {}
+  explicit Map(Scalar const* coeffs) : quaternion_(coeffs) {}
 
   /// Accessor of quaternion.
   ///

--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -778,7 +778,7 @@ class Map<Sophus::SE2<Scalar_>, Options>
   using Base::operator*;
 
   SOPHUS_FUNC
-  Map(Scalar* coeffs)
+  explicit Map(Scalar* coeffs)
       : so2_(coeffs),
         translation_(coeffs + Sophus::SO2<Scalar>::num_parameters) {}
 
@@ -827,7 +827,7 @@ class Map<Sophus::SE2<Scalar_> const, Options>
   using Base::operator*=;
   using Base::operator*;
 
-  SOPHUS_FUNC Map(Scalar const* coeffs)
+  SOPHUS_FUNC explicit Map(Scalar const* coeffs)
       : so2_(coeffs),
         translation_(coeffs + Sophus::SO2<Scalar>::num_parameters) {}
 

--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -1016,7 +1016,7 @@ class Map<Sophus::SE3<Scalar_>, Options>
   using Base::operator*=;
   using Base::operator*;
 
-  SOPHUS_FUNC Map(Scalar* coeffs)
+  SOPHUS_FUNC explicit Map(Scalar* coeffs)
       : so3_(coeffs),
         translation_(coeffs + Sophus::SO3<Scalar>::num_parameters) {}
 
@@ -1065,7 +1065,7 @@ class Map<Sophus::SE3<Scalar_> const, Options>
   using Base::operator*=;
   using Base::operator*;
 
-  SOPHUS_FUNC Map(Scalar const* coeffs)
+  SOPHUS_FUNC explicit Map(Scalar const* coeffs)
       : so3_(coeffs),
         translation_(coeffs + Sophus::SO3<Scalar>::num_parameters) {}
 

--- a/sophus/sim2.hpp
+++ b/sophus/sim2.hpp
@@ -730,7 +730,7 @@ class Map<Sophus::Sim2<Scalar_>, Options>
   using Base::operator*=;
   using Base::operator*;
 
-  SOPHUS_FUNC Map(Scalar* coeffs)
+  SOPHUS_FUNC explicit Map(Scalar* coeffs)
       : rxso2_(coeffs),
         translation_(coeffs + Sophus::RxSO2<Scalar>::num_parameters) {}
 
@@ -778,7 +778,7 @@ class Map<Sophus::Sim2<Scalar_> const, Options>
   using Base::operator*=;
   using Base::operator*;
 
-  SOPHUS_FUNC Map(Scalar const* coeffs)
+  SOPHUS_FUNC explicit Map(Scalar const* coeffs)
       : rxso2_(coeffs),
         translation_(coeffs + Sophus::RxSO2<Scalar>::num_parameters) {}
 

--- a/sophus/sim3.hpp
+++ b/sophus/sim3.hpp
@@ -763,7 +763,7 @@ class Map<Sophus::Sim3<Scalar_>, Options>
   using Base::operator*=;
   using Base::operator*;
 
-  SOPHUS_FUNC Map(Scalar* coeffs)
+  SOPHUS_FUNC explicit Map(Scalar* coeffs)
       : rxso3_(coeffs),
         translation_(coeffs + Sophus::RxSO3<Scalar>::num_parameters) {}
 
@@ -812,7 +812,7 @@ class Map<Sophus::Sim3<Scalar_> const, Options>
   using Base::operator*=;
   using Base::operator*;
 
-  SOPHUS_FUNC Map(Scalar const* coeffs)
+  SOPHUS_FUNC explicit Map(Scalar const* coeffs)
       : rxso3_(coeffs),
         translation_(coeffs + Sophus::RxSO3<Scalar>::num_parameters) {}
 

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -578,7 +578,7 @@ class Map<Sophus::SO2<Scalar_>, Options>
   using Base::operator*;
 
   SOPHUS_FUNC
-  Map(Scalar* coeffs) : unit_complex_(coeffs) {}
+  explicit Map(Scalar* coeffs) : unit_complex_(coeffs) {}
 
   /// Accessor of unit complex number.
   ///
@@ -617,7 +617,7 @@ class Map<Sophus::SO2<Scalar_> const, Options>
   using Base::operator*=;
   using Base::operator*;
 
-  SOPHUS_FUNC Map(Scalar const* coeffs) : unit_complex_(coeffs) {}
+  SOPHUS_FUNC explicit Map(Scalar const* coeffs) : unit_complex_(coeffs) {}
 
   /// Accessor of unit complex number.
   ///

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -808,7 +808,7 @@ class Map<Sophus::SO3<Scalar_>, Options>
   using Base::operator*=;
   using Base::operator*;
 
-  SOPHUS_FUNC Map(Scalar* coeffs) : unit_quaternion_(coeffs) {}
+  SOPHUS_FUNC explicit Map(Scalar* coeffs) : unit_quaternion_(coeffs) {}
 
   /// Accessor of unit quaternion.
   ///
@@ -847,7 +847,7 @@ class Map<Sophus::SO3<Scalar_> const, Options>
   using Base::operator*=;
   using Base::operator*;
 
-  SOPHUS_FUNC Map(Scalar const* coeffs) : unit_quaternion_(coeffs) {}
+  SOPHUS_FUNC explicit Map(Scalar const* coeffs) : unit_quaternion_(coeffs) {}
 
   /// Accessor of unit quaternion.
   ///


### PR DESCRIPTION
- Making them explicit avoids unwanted implicit conversion from
  Scalar* to Eigen::Map<Sophus::...<Scalar>>.
- The constructors not yet being explicit might have just been an
  oversight.
- Eigen::Map constructors in Eigen are explicit, see e.g.:
  - https://gitlab.com/libeigen/eigen/-/blob/0d73440fb212abb778fc7d662fb6a621252feda4/Eigen/src/Core/Map.h#L131
  - https://gitlab.com/libeigen/eigen/-/blob/0d73440fb212abb778fc7d662fb6a621252feda4/Eigen/src/Geometry/Quaternion.h#L420