### PR TITLE
fix sympy failures

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,11 +12,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04]
+        os: [ubuntu-20.04]
       fail-fast: false
     env:
       BUILD_TYPE: Coverage
-
 
 
     steps:
@@ -32,9 +31,8 @@ jobs:
 
       - name: Install Coverage
         run: |
-          wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.14.orig.tar.gz
-          tar xf lcov_1.14.orig.tar.gz
-          sudo make -C lcov-1.14/ install
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
+            lcov
 
       - name: Run tests for coverage
         run: |

--- a/.github/workflows/sympy.yml
+++ b/.github/workflows/sympy.yml
@@ -21,6 +21,6 @@ jobs:
 
       - name: Run sympy tests
         run: |
-          pip3 install sympy
+          pip3 install sympy==1.8
           cd sympy
           ./run_tests.sh


### PR DESCRIPTION
With SymPy version 1.9, computing the limits in SO(3) Jacobian results in an error and consequently CI failures. While it is possible to solve the issue by switching to the [Gruntz algorithm](https://docs.sympy.org/latest/modules/series/series.html#the-gruntz-algorithm) for limits computation, other issues arise. Particularly, the code generator produces results varying between SymPy releases. Therefore, the easiest workaround is to pin the SymPy version to the last version known to be working.

Also, the `ubuntu-16.04` runner [has been removed](https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/). Switch to `ubuntu-20.04` runner.