### PR TITLE
eliminate boilerplate code

### DIFF
--- a/sophus/sim_details.hpp
+++ b/sophus/sim_details.hpp
@@ -13,7 +13,6 @@ Matrix<Scalar, N, N> calcW(Matrix<Scalar, N, N> const &Omega,
   using std::cos;
   using std::exp;
   using std::sin;
-  static Matrix<Scalar, N, N> const I = Matrix<Scalar, N, N>::Identity();
   static Scalar const one(1);
   static Scalar const half(0.5);
   Matrix<Scalar, N, N> const Omega2 = Omega * Omega;
@@ -45,7 +44,7 @@ Matrix<Scalar, N, N> calcW(Matrix<Scalar, N, N> const &Omega,
       B = (C - ((b - one) * sigma + a * theta) / (c)) * one / (theta_sq);
     }
   }
-  return A * Omega + B * Omega2 + C * I;
+  return A * Omega + B * Omega2 + C * Matrix<Scalar, N, N>::Identity();
 }
 
 template <class Scalar>
@@ -146,7 +145,6 @@ Matrix<Scalar, N, N> calcWInv(Matrix<Scalar, N, N> const &Omega,
   using std::abs;
   using std::cos;
   using std::sin;
-  static Matrix<Scalar, N, N> const I = Matrix<Scalar, N, N>::Identity();
   static Scalar const half(0.5);
   static Scalar const one(1);
   static Scalar const two(2);
@@ -185,7 +183,7 @@ Matrix<Scalar, N, N> calcWInv(Matrix<Scalar, N, N> const &Omega,
                        two * s_cos_theta + scale - one));
     }
   }
-  return a * Omega + b * Omega2 + c * I;
+  return a * Omega + b * Omega2 + c * Matrix<Scalar, N, N>::Identity();
 }
 
 }  // namespace details

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -370,7 +370,7 @@ class SO2 : public SO2Base<SO2<Scalar_, Options>> {
 
   /// Default constructor initializes unit complex number to identity rotation.
   ///
-  SOPHUS_FUNC SO2() : unit_complex_(Scalar(1), Scalar(0)) {}
+  SOPHUS_FUNC SO2() : unit_complex_(Matrix<Scalar, 2, 1>::UnitX()) {}
 
   /// Copy constructor
   ///
@@ -387,8 +387,8 @@ class SO2 : public SO2Base<SO2<Scalar_, Options>> {
   /// Precondition: rotation matrix need to be orthogonal with determinant of 1.
   ///
   SOPHUS_FUNC explicit SO2(Transformation const& R)
-      : unit_complex_(Scalar(0.5) * (R(0, 0) + R(1, 1)),
-                      Scalar(0.5) * (R(1, 0) - R(0, 1))) {
+      : unit_complex_(Scalar(0.5) * Matrix<Scalar, 2, 1>{R.diagonal().sum(),
+                                                         R(1, 0) - R(0, 1)}) {
     SOPHUS_ENSURE(isOrthogonal(R), "R is not orthogonal:\n {}", R);
     SOPHUS_ENSURE(R.determinant() > Scalar(0), "det(R) is not positive: {}",
                   R.determinant());
@@ -455,7 +455,7 @@ class SO2 : public SO2Base<SO2<Scalar_, Options>> {
   ///
   SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF>
   Dx_exp_x_at_0() {
-    return Sophus::Matrix<Scalar, num_parameters, DoF>(Scalar(0), Scalar(1));
+    return Sophus::Matrix<Scalar, num_parameters, DoF>::UnitY();
   }
 
   /// Returns derivative of exp(x).matrix() wrt. ``x_i at x=0``.

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -135,7 +135,7 @@ class SO3Base {
   template <class S = Scalar>
   SOPHUS_FUNC enable_if_t<std::is_floating_point<S>::value, S> angleX() const {
     Sophus::Matrix3<Scalar> R = matrix();
-    Sophus::Matrix2<Scalar> Rx = R.template block<2, 2>(1, 1);
+    Sophus::Matrix2<Scalar> Rx = R.template bottomRightCorner<2, 2>();
     return SO2<Scalar>(makeRotationMatrix(Rx)).log();
   }
 
@@ -158,7 +158,7 @@ class SO3Base {
   template <class S = Scalar>
   SOPHUS_FUNC enable_if_t<std::is_floating_point<S>::value, S> angleZ() const {
     Sophus::Matrix3<Scalar> R = matrix();
-    Sophus::Matrix2<Scalar> Rz = R.template block<2, 2>(0, 0);
+    Sophus::Matrix2<Scalar> Rz = R.template topLeftCorner<2, 2>();
     return SO2<Scalar>(makeRotationMatrix(Rz)).log();
   }
 
@@ -747,6 +747,7 @@ class SO3 : public SO3Base<SO3<Scalar_, Options>> {
     const Scalar u2 = uniform_twopi(generator);
     const Scalar u3 = uniform_twopi(generator);
 
+    using std::sqrt;
     const Scalar a = sqrt(1 - u1);
     const Scalar b = sqrt(u1);
 


### PR DESCRIPTION
This PR eliminates some of the boilerplate present in Sophus and makes the code more compact. Particularly,
* ~~Replaced hand-rolled complex number multiplication by `std::complex`~~ (postponed due to missing `ceres::Jet` overload for `copysign`)
* Vectorized operations in multiple places
* Removed open TODO
* Fixed SE(2) comments

This PR is a continuation of #282.