### PR TITLE
remove unused FMT_STRING_ALIAS (to fix compilation with old libfmt)

### DIFF
--- a/sophus/common.hpp
+++ b/sophus/common.hpp
@@ -33,12 +33,6 @@
 #endif
 #endif
 
-#undef FMT_STRING_ALIAS
-#ifdef SOPHUS_COMPILE_TIME_FMT
-// enable compile time FMT feature
-#define FMT_STRING_ALIAS 1
-#endif
-
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/ostream.h>


### PR DESCRIPTION
- This define used to enable the `fmt` macro as an alias to
  `FMT_STRING`, but the code uses `FMT_STRING` already anyway,
  so it is not needed for any version of libfmt.
- Since libfmt 7.0 this macro has been removed and it has no
  effect in any case.
  (https://github.com/fmtlib/fmt/blob/master/ChangeLog.rst)
- For older versions, it causes `fmt` to be defined as a macro,
  which can break other code and lead to weird error messages,
  for example in Pangolin.
  (https://github.com/stevenlovegrove/Pangolin/issues/663)