### PR TITLE
remove trivial special members

### DIFF
--- a/sophus/rxso2.hpp
+++ b/sophus/rxso2.hpp
@@ -427,11 +427,6 @@ class RxSO2 : public RxSO2Base<RxSO2<Scalar_, Options>> {
 
   using Base::operator=;
 
-  /// Define copy-assignment operator explicitly. The definition of
-  /// implicit copy assignment operator is deprecated in presence of a
-  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
-  SOPHUS_FUNC RxSO2& operator=(RxSO2 const& other) = default;
-
   static int constexpr DoF = Base::DoF;
   static int constexpr num_parameters = Base::num_parameters;
 
@@ -441,10 +436,6 @@ class RxSO2 : public RxSO2Base<RxSO2<Scalar_, Options>> {
   /// scale to 1.
   ///
   SOPHUS_FUNC RxSO2() : complex_(Scalar(1), Scalar(0)) {}
-
-  /// Copy constructor
-  ///
-  SOPHUS_FUNC RxSO2(RxSO2 const& other) = default;
 
   /// Copy-like constructor from OtherDerived.
   ///

--- a/sophus/rxso3.hpp
+++ b/sophus/rxso3.hpp
@@ -485,11 +485,6 @@ class RxSO3 : public RxSO3Base<RxSO3<Scalar_, Options>> {
 
   using Base::operator=;
 
-  /// Define copy-assignment operator explicitly. The definition of
-  /// implicit copy assignment operator is deprecated in presence of a
-  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
-  SOPHUS_FUNC RxSO3& operator=(RxSO3 const& other) = default;
-
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes quaternion to identity rotation and scale
@@ -497,10 +492,6 @@ class RxSO3 : public RxSO3Base<RxSO3<Scalar_, Options>> {
   ///
   SOPHUS_FUNC RxSO3()
       : quaternion_(Scalar(1), Scalar(0), Scalar(0), Scalar(0)) {}
-
-  /// Copy constructor
-  ///
-  SOPHUS_FUNC RxSO3(RxSO3 const& other) = default;
 
   /// Copy-like constructor from OtherDerived
   ///

--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -393,20 +393,11 @@ class SE2 : public SE2Base<SE2<Scalar_, Options>> {
 
   using Base::operator=;
 
-  /// Define copy-assignment operator explicitly. The definition of
-  /// implicit copy assignment operator is deprecated in presence of a
-  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
-  SOPHUS_FUNC SE2& operator=(SE2 const& other) = default;
-
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes rigid body motion to the identity.
   ///
   SOPHUS_FUNC SE2();
-
-  /// Copy constructor
-  ///
-  SOPHUS_FUNC SE2(SE2 const& other) = default;
 
   /// Copy-like constructor from OtherDerived
   ///

--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -456,20 +456,11 @@ class SE3 : public SE3Base<SE3<Scalar_, Options>> {
 
   using Base::operator=;
 
-  /// Define copy-assignment operator explicitly. The definition of
-  /// implicit copy assignment operator is deprecated in presence of a
-  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
-  SOPHUS_FUNC SE3& operator=(SE3 const& other) = default;
-
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes rigid body motion to the identity.
   ///
   SOPHUS_FUNC SE3();
-
-  /// Copy constructor
-  ///
-  SOPHUS_FUNC SE3(SE3 const& other) = default;
 
   /// Copy-like constructor from OtherDerived.
   ///

--- a/sophus/sim2.hpp
+++ b/sophus/sim2.hpp
@@ -393,11 +393,6 @@ class Sim2 : public Sim2Base<Sim2<Scalar_, Options>> {
 
   using Base::operator=;
 
-  /// Define copy-assignment operator explicitly. The definition of
-  /// implicit copy assignment operator is deprecated in presence of a
-  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
-  SOPHUS_FUNC Sim2& operator=(Sim2 const& other) = default;
-
   static int constexpr DoF = Base::DoF;
   static int constexpr num_parameters = Base::num_parameters;
 
@@ -406,10 +401,6 @@ class Sim2 : public Sim2Base<Sim2<Scalar_, Options>> {
   /// Default constructor initializes similarity transform to the identity.
   ///
   SOPHUS_FUNC Sim2();
-
-  /// Copy constructor
-  ///
-  SOPHUS_FUNC Sim2(Sim2 const& other) = default;
 
   /// Copy-like constructor from OtherDerived.
   ///

--- a/sophus/sim3.hpp
+++ b/sophus/sim3.hpp
@@ -394,20 +394,11 @@ class Sim3 : public Sim3Base<Sim3<Scalar_, Options>> {
 
   using Base::operator=;
 
-  /// Define copy-assignment operator explicitly. The definition of
-  /// implicit copy assignment operator is deprecated in presence of a
-  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
-  SOPHUS_FUNC Sim3& operator=(Sim3 const& other) = default;
-
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes similarity transform to the identity.
   ///
   SOPHUS_FUNC Sim3();
-
-  /// Copy constructor
-  ///
-  SOPHUS_FUNC Sim3(Sim3 const& other) = default;
 
   /// Copy-like constructor from OtherDerived.
   ///

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -365,20 +365,11 @@ class SO2 : public SO2Base<SO2<Scalar_, Options>> {
 
   using Base::operator=;
 
-  /// Define copy-assignment operator explicitly. The definition of
-  /// implicit copy assignment operator is deprecated in presence of a
-  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
-  SOPHUS_FUNC SO2& operator=(SO2 const& other) = default;
-
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes unit complex number to identity rotation.
   ///
   SOPHUS_FUNC SO2() : unit_complex_(Scalar(1), Scalar(0)) {}
-
-  /// Copy constructor
-  ///
-  SOPHUS_FUNC SO2(SO2 const& other) = default;
 
   /// Copy-like constructor from OtherDerived.
   ///

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -460,21 +460,12 @@ class SO3 : public SO3Base<SO3<Scalar_, Options>> {
 
   using Base::operator=;
 
-  /// Define copy-assignment operator explicitly. The definition of
-  /// implicit copy assignment operator is deprecated in presence of a
-  /// user-declared copy constructor (-Wdeprecated-copy in clang >= 13).
-  SOPHUS_FUNC SO3& operator=(SO3 const& other) = default;
-
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor initializes unit quaternion to identity rotation.
   ///
   SOPHUS_FUNC SO3()
       : unit_quaternion_(Scalar(1), Scalar(0), Scalar(0), Scalar(0)) {}
-
-  /// Copy constructor
-  ///
-  SOPHUS_FUNC SO3(SO3 const& other) = default;
 
   /// Copy-like constructor from OtherDerived.
   ///


### PR DESCRIPTION
This is a followup to #327. Most of the special members can be generated by the compiler and don't need to be defined explicitly. Removing the default special members brings class definitions closer to fulfilling the rule of zero.