### PR TITLE
Add missing SOPHUS_FUNC tags to some function definitions

### DIFF
--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -747,7 +747,7 @@ class SE2 : public SE2Base<SE2<Scalar_, Options>> {
 };
 
 template <class Scalar, int Options>
-SE2<Scalar, Options>::SE2() : translation_(TranslationMember::Zero()) {
+SOPHUS_FUNC SE2<Scalar, Options>::SE2() : translation_(TranslationMember::Zero()) {
   static_assert(std::is_standard_layout<SE2>::value,
                 "Assume standard layout for the use of offsetof check below.");
   static_assert(

--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -1020,7 +1020,7 @@ class SE3 : public SE3Base<SE3<Scalar_, Options>> {
 };
 
 template <class Scalar, int Options>
-SE3<Scalar, Options>::SE3() : translation_(TranslationMember::Zero()) {
+SOPHUS_FUNC SE3<Scalar, Options>::SE3() : translation_(TranslationMember::Zero()) {
   static_assert(std::is_standard_layout<SE3>::value,
                 "Assume standard layout for the use of offsetof check below.");
   static_assert(

--- a/sophus/sim2.hpp
+++ b/sophus/sim2.hpp
@@ -700,7 +700,7 @@ class Sim2 : public Sim2Base<Sim2<Scalar_, Options>> {
 };
 
 template <class Scalar, int Options>
-Sim2<Scalar, Options>::Sim2() : translation_(TranslationMember::Zero()) {
+SOPHUS_FUNC Sim2<Scalar, Options>::Sim2() : translation_(TranslationMember::Zero()) {
   static_assert(std::is_standard_layout<Sim2>::value,
                 "Assume standard layout for the use of offsetof check below.");
   static_assert(

--- a/sophus/sim3.hpp
+++ b/sophus/sim3.hpp
@@ -733,7 +733,7 @@ class Sim3 : public Sim3Base<Sim3<Scalar_, Options>> {
 };
 
 template <class Scalar, int Options>
-Sim3<Scalar, Options>::Sim3() : translation_(TranslationMember::Zero()) {
+SOPHUS_FUNC Sim3<Scalar, Options>::Sim3() : translation_(TranslationMember::Zero()) {
   static_assert(std::is_standard_layout<Sim3>::value,
                 "Assume standard layout for the use of offsetof check below.");
   static_assert(


### PR DESCRIPTION
Add missing SOPHUS_FUNC tags to some function definitions. This was preventing their use in CUDA.