### PR TITLE
ignore sympy folder in run_format.sh

### DIFF
--- a/run_format.sh
+++ b/run_format.sh
@@ -1,1 +1,1 @@
-find . -type d \( -path ./py -o -path ./doxyrest_b -o -path "./*/CMakeFiles/*" \) -prune -o  -iname *.hpp -o -iname *.cpp -print | xargs clang-format -i
+find . -type d \( -path ./sympy -o -path ./doxyrest_b -o -path "./*/CMakeFiles/*" \) -prune -o  -iname *.hpp -o -iname *.cpp -print | xargs clang-format -i

--- a/run_format.sh
+++ b/run_format.sh
@@ -1,1 +1,1 @@
-find . -type d \( -path ./sympy -o -path ./doxyrest_b -o -path "./*/CMakeFiles/*" \) -prune -o  -iname *.hpp -o -iname *.cpp -print | xargs clang-format -i
+find . -type d \( -path ./sympy -o -path ./doxyrest_b -o -path "./*/CMakeFiles/*" \) -prune -o \( -iname "*.hpp" -o -iname "*.cpp" \) -print | xargs clang-format -i


### PR DESCRIPTION
The sympy folder contains generated cpp files which we don't want to
auto-format.

This was apparently missed during the py -> sympy folder rename:
4da9a55431ea4cd48ec8a68ad996a2801e288e6a

See: https://github.com/strasdat/Sophus/pull/342#issuecomment-1072592484