### PR TITLE
cmake: update 'custom' target with all header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library (Sophus::Sophus ALIAS sophus)
 
 set(SOPHUS_HEADER_FILES
   sophus/average.hpp
+  sophus/ceres_local_parameterization.hpp
   sophus/common.hpp
   sophus/geometry.hpp
   sophus/interpolate.hpp
@@ -134,7 +135,7 @@ target_compile_features (sophus INTERFACE
 )
 
 # Add sources as custom target so that they are shown in IDE's
-add_custom_target(other SOURCES ${SOPHUS_OTHER_FILES})
+add_custom_target(other SOURCES ${SOPHUS_OTHER_FILES} ${SOPHUS_HEADER_FILES})
 
 # Create 'test' make target using ctest
 option(BUILD_SOPHUS_TESTS "Build tests." ON)


### PR DESCRIPTION
Recent versions of QtCreator only associate header files with the
project that are explicitly mentioned as sources of some
target. Without this change, the Sophus headers were not picked up as
project files. This is a problem, since for example, it breaks the
"clang-format on file save" feature.