### PR TITLE
Install ccache via scripts/install_linux_deps.sh

### DIFF
--- a/scripts/install_linux_deps.sh
+++ b/scripts/install_linux_deps.sh
@@ -6,7 +6,7 @@ set -e # exit on error
 cmake --version
 
 sudo apt-get -qq update
-sudo apt-get install gfortran libc++-dev libgoogle-glog-dev libatlas-base-dev libsuitesparse-dev libceres-dev
+sudo apt-get install gfortran libc++-dev libgoogle-glog-dev libatlas-base-dev libsuitesparse-dev libceres-dev ccache
 wget https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.tar.bz2
 tar xvf eigen-3.3.4.tar.bz2
 mkdir build-eigen


### PR DESCRIPTION
Line 23 of `scripts/install_linux_deps.sh` invokes `ccache` which may not be present on the host machine. This PR ensures `ccache` is installed prior. 

Signed-off-by: Yadunund <yadunund@openrobotics.org>