### PR TITLE
Add missing header files (ceres manifold).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ set(SOPHUS_HEADER_FILES
   sophus/average.hpp
   sophus/cartesian.hpp
   sophus/ceres_local_parameterization.hpp
+  sophus/ceres_manifold.hpp
+  sophus/ceres_typetraits.hpp
   sophus/common.hpp
   sophus/geometry.hpp
   sophus/interpolate.hpp


### PR DESCRIPTION
Add new ceres manifold-related files to SOPHUS_HEADER_FILES.

I kept the ceres_local_param file still in there for compatibility. Maybe it can be removed in a future release.

Related to #355