### PR TITLE
Look for Ceres 2.1.0

### DIFF
--- a/test/ceres/CMakeLists.txt
+++ b/test/ceres/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND SEARCH_HEADERS ${EIGEN3_INCLUDE_DIR})
 
 # git clone https://ceres-solver.googlesource.com/ceres-solver
-find_package(Ceres 2.0.0 QUIET)
+find_package(Ceres 2.1.0 QUIET)
 
 function(add_test_ceres source postfix)
   add_executable(${source}_${postfix} ${source}.cpp)

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -12,7 +12,7 @@ SET( TEST_SOURCES test_common
                   test_sim3
                   test_velocities
                   test_geometry)
-find_package( Ceres 2.0.0 QUIET )
+find_package( Ceres 2.1.0 QUIET )
 
 FOREACH(test_src ${TEST_SOURCES})
   ADD_EXECUTABLE( ${test_src} ${test_src}.cpp tests.hpp ../../sophus/test_macros.hpp)


### PR DESCRIPTION
Originally, the ceres test CMakeLists.txt only required Ceres 2.0.0.
However, this version doesn't define ceres/manifold, and therefore
when compiling against Ceres 2.0.0 the compilation fails.

See #359 

I don't claim that this is the optimal solution, however it solves the issue for me. It might be useful to reference the necessary Ceres version somewhere in this repo to avoid confusion in the future. As I already had both Eigen and Ceres installed I assumed I didn't have to execute the installation scripts. 