### PR TITLE
Add Sim3 constructor from scale, unit quaternion, and translation

### DIFF
--- a/sophus/rxso3.hpp
+++ b/sophus/rxso3.hpp
@@ -582,6 +582,14 @@ class RxSO3 : public RxSO3Base<RxSO3<Scalar_, Options>> {
         "Inverse scale factor must be greater-equal epsilon.");
   }
 
+  /// Constructor from scale factor and unit quaternion
+  ///
+  /// Precondition: quaternion must not be close to zero.
+  ///
+  template <class D>
+  SOPHUS_FUNC explicit RxSO3(Scalar const& scale, Eigen::QuaternionBase<D> const& unit_quat)
+      : RxSO3(scale, SO3<Scalar>(unit_quat)) {}
+
   /// Accessor of quaternion.
   ///
   SOPHUS_FUNC QuaternionMember const& quaternion() const { return quaternion_; }

--- a/sophus/sim3.hpp
+++ b/sophus/sim3.hpp
@@ -432,7 +432,7 @@ class Sim3 : public Sim3Base<Sim3<Scalar_, Options>> {
   /// Constructor from RxSO3 and translation vector
   ///
   template <class OtherDerived, class D>
-  SOPHUS_FUNC Sim3(RxSO3Base<OtherDerived> const& rxso3,
+  SOPHUS_FUNC explicit Sim3(RxSO3Base<OtherDerived> const& rxso3,
                    Eigen::MatrixBase<D> const& translation)
       : rxso3_(rxso3), translation_(translation) {
     static_assert(std::is_same<typename OtherDerived::Scalar, Scalar>::value,
@@ -446,7 +446,7 @@ class Sim3 : public Sim3Base<Sim3<Scalar_, Options>> {
   /// Precondition: quaternion must not be close to zero.
   ///
   template <class D1, class D2>
-  SOPHUS_FUNC Sim3(Eigen::QuaternionBase<D1> const& quaternion,
+  SOPHUS_FUNC explicit Sim3(Eigen::QuaternionBase<D1> const& quaternion,
                    Eigen::MatrixBase<D2> const& translation)
       : rxso3_(quaternion), translation_(translation) {
     static_assert(std::is_same<typename D1::Scalar, Scalar>::value,
@@ -454,6 +454,16 @@ class Sim3 : public Sim3Base<Sim3<Scalar_, Options>> {
     static_assert(std::is_same<typename D2::Scalar, Scalar>::value,
                   "must be same Scalar type");
   }
+
+  /// Constructor from scale factor, unit quaternion, and translation vector.
+  ///
+  /// Precondition: quaternion must not be close to zero.
+  ///
+  template <class D1, class D2>
+  SOPHUS_FUNC explicit Sim3(Scalar const& scale,
+                   Eigen::QuaternionBase<D1> const& unit_quaternion,
+                   Eigen::MatrixBase<D2> const& translation)
+      : Sim3(RxSO3<Scalar>(scale, unit_quaternion), translation) {}
 
   /// Constructor from 4x4 matrix
   ///

--- a/test/core/test_rxso3.cpp
+++ b/test/core/test_rxso3.cpp
@@ -247,7 +247,12 @@ class Tests {
                        Constants<Scalar>::epsilon(), "RxSO3(scale, SO3)");
     SOPHUS_TEST_APPROX(passed, RxSO3Type(scale, so3.matrix()).matrix(),
                        rxso3.matrix(), Constants<Scalar>::epsilon(),
-                       "RxSO3(scale, SO3)");
+                       "RxSO3(scale, matrix3x3)");
+    const Eigen::Quaternion<Scalar> q = Eigen::Quaternion<Scalar>::UnitRandom();
+    SOPHUS_TEST_APPROX(passed, RxSO3Type(scale, q).matrix(),
+                       RxSO3Type(scale, SO3<Scalar>(q)).matrix(),
+                       Constants<Scalar>::epsilon(),
+                       "RxSO3(scale, unit_quaternion)");
     Matrix3<Scalar> R =
         SO3<Scalar>::exp(Point(Scalar(0.2), Scalar(0.5), Scalar(-1.0)))
             .matrix();

--- a/test/core/test_sim3.cpp
+++ b/test/core/test_sim3.cpp
@@ -227,12 +227,17 @@ class Tests {
     RxSO3Type rxso3 = sim3.rxso3();
 
     SOPHUS_TEST_APPROX(passed, Sim3Type(rxso3, translation).matrix(),
-                       sim3.matrix(), Constants<Scalar>::epsilon(), "");
+                       sim3.matrix(), Constants<Scalar>::epsilon(), "Sim3(RxSO3, translation)");
     SOPHUS_TEST_APPROX(passed,
                        Sim3Type(rxso3.quaternion(), translation).matrix(),
-                       sim3.matrix(), Constants<Scalar>::epsilon(), "");
+                       sim3.matrix(), Constants<Scalar>::epsilon(),
+                       "Sim3(quaternion, translation)");
+    SOPHUS_TEST_APPROX(passed,
+                       Sim3Type(rxso3.scale(), rxso3.quaternion().normalized(), translation).matrix(),
+                       sim3.matrix(), Constants<Scalar>::epsilon(),
+                       "Sim3(scale, unit_quaternion, translation)");
     SOPHUS_TEST_APPROX(passed, Sim3Type(sim3.matrix()).matrix(), sim3.matrix(),
-                       Constants<Scalar>::epsilon(), "");
+                       Constants<Scalar>::epsilon(), "Sim3(matrix4x4)");
 
     Scalar scale(1.2);
     sim3.setScale(scale);


### PR DESCRIPTION
It would be convenient to allow directly constructing `Sim3` from scale, unit quaternion, translation (e.g., `Sophus::Sim3d(scale, quat, trans)`). The current best ways seem like `Sim3d(RxSO3d(scale, SO3d(quat)), pos)` or `Sim3d(Eigen::Quaterniond(quat.coeffs() * std::sqrt(scale)), trans)`, which may not obvious for novice users. Note that `RxSO3d(scale, quat)` is not allowed because the SO3 constructor from quaternion is explicit.