### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ modern configurations as long they support c++14, CMake, Eigen 3.3.X and
 Installing Sophus (vcpkg)
 ----------------------------
 
-You can build and install Sophus using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+You can build and install Sophus using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager::
 
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg

--- a/README.rst
+++ b/README.rst
@@ -43,15 +43,15 @@ modern configurations as long they support c++14, CMake, Eigen 3.3.X and
 .. |GithubCISympy| image:: https://github.com/strasdat/Sophus/actions/workflows/sympy.yml/badge.svg?branch=master
 .. _GithubCISympy: https://github.com/strasdat/Sophus/actions/workflows/sympy.yml?query=branch%3Amaster
 
-Installing LuaBridge (vcpkg)
+Installing Sophus (vcpkg)
 ----------------------------
 
 You can build and install Sophus using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
 
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install sophus
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install sophus
 
 The Sophus port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.

--- a/README.rst
+++ b/README.rst
@@ -48,10 +48,10 @@ Installing Sophus (vcpkg)
 
 You can build and install Sophus using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager::
 
-git clone https://github.com/Microsoft/vcpkg.git
-cd vcpkg
-./bootstrap-vcpkg.sh
-./vcpkg integrate install
-./vcpkg install sophus
+$ git clone https://github.com/Microsoft/vcpkg.git
+$ cd vcpkg
+$ ./bootstrap-vcpkg.sh
+$ ./vcpkg integrate install
+$ ./vcpkg install sophus
 
 The Sophus port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.

--- a/README.rst
+++ b/README.rst
@@ -42,3 +42,16 @@ modern configurations as long they support c++14, CMake, Eigen 3.3.X and
 
 .. |GithubCISympy| image:: https://github.com/strasdat/Sophus/actions/workflows/sympy.yml/badge.svg?branch=master
 .. _GithubCISympy: https://github.com/strasdat/Sophus/actions/workflows/sympy.yml?query=branch%3Amaster
+
+Installing LuaBridge (vcpkg)
+----------------------------
+
+You can build and install Sophus using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install sophus
+
+The Sophus port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
`Sophus` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `Sophus` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `Sophus`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/sophus/portfile.cmake). We try to keep the library maintained as close as possible to the original library. 😊