### PR TITLE
Enable visitation pattern for RuntimeImage

### DIFF
--- a/cpp/sophus/image/image.h
+++ b/cpp/sophus/image/image.h
@@ -191,11 +191,7 @@ class MutImage : public MutImageView<TPixel> {
   std::shared_ptr<uint8_t> shared_;  // NOLINT
 };
 
-template <
-    template <typename>
-    class TPredicate,
-    template <typename>
-    class TAllocator>
+template <class TPredicate, template <typename> class TAllocator>
 class RuntimeImage;
 
 /// Image read-only access to pixels and shared ownership, hence cheap to copy.
@@ -264,11 +260,7 @@ class Image : public ImageView<TPixel> {
   template <class TT, template <typename> class TAllocator2T>
   friend class MutImage;
 
-  template <
-      template <typename>
-      class TPredicate,
-      template <typename>
-      class TAllocator2T>
+  template <class TPredicate, template <typename> class TAllocator2T>
   friend class RuntimeImage;
 
   explicit Image(ImageView<TPixel> view) : ImageView<TPixel>(view) {}

--- a/cpp/sophus/image/image_view.h
+++ b/cpp/sophus/image/image_view.h
@@ -161,6 +161,20 @@ struct ImageView {
   }
 
   /// Performs reduction / fold on image view.
+  template <class TFunc>
+  void visit(TFunc const& user_function) const {
+    FARM_CHECK(!this->isEmpty());
+
+    for (int v = 0; v < this->shape_.height(); ++v) {
+      TPixel const* p = this->rowPtr(v);
+      TPixel const* end_of_row = p + this->shape_.width();
+      for (; p != end_of_row; ++p) {
+        user_function(*p);
+      }
+    }
+  }
+
+  /// Performs reduction / fold on image view.
   template <class TReduceOp, class TVal>
   [[nodiscard]] TVal reduce(
       TReduceOp const& reduce_op, TVal val = TVal{}) const {

--- a/cpp/sophus/image/runtime_image.h
+++ b/cpp/sophus/image/runtime_image.h
@@ -265,7 +265,7 @@ template <
     typename UserFunc,
     class TPredicate = IntensityImagePredicate,
     template <typename> class TAllocator = Eigen::aligned_allocator>
-decltype(auto) visit(
+void visitImage(
     UserFunc&& func, RuntimeImage<TPredicate, TAllocator> const& image) {
   using TRuntimeImage = RuntimeImage<TPredicate, TAllocator>;
   detail::

--- a/cpp/sophus/image/runtime_image.h
+++ b/cpp/sophus/image/runtime_image.h
@@ -230,47 +230,47 @@ using IntensityImage = RuntimeImage<IntensityImagePredicate, TAllocator>;
 namespace detail {
 // Call UserFunc with TRuntimeImage cast to the appropriate concrete type
 // from the options in PixelTypes...
-template <typename UserFunc, typename TRuntimeImage, typename... PixelTypes>
+template <typename TUserFunc, typename TRuntimeImage, typename... TPixelTypes>
 struct VisitImpl;
 
 // base case
-template <typename UserFunc, typename TRuntimeImage, typename PixelType>
-struct VisitImpl<UserFunc, TRuntimeImage, std::variant<PixelType>> {
-  static void visit(UserFunc&& func, TRuntimeImage const& image) {
-    if (image.pixelType().template is<PixelType>()) {
-      func(image.template image<PixelType>());
+template <typename TUserFunc, typename TRuntimeImage, typename TPixelType>
+struct VisitImpl<TUserFunc, TRuntimeImage, std::variant<TPixelType>> {
+  static void visit(TUserFunc&& func, TRuntimeImage const& image) {
+    if (image.pixelType().template is<TPixelType>()) {
+      func(image.template image<TPixelType>());
     }
   }
 };
 
 // inductive case
 template <
-    typename UserFunc,
+    typename TUserFunc,
     typename TRuntimeImage,
-    typename PixelType,
-    typename... Rest>
-struct VisitImpl<UserFunc, TRuntimeImage, std::variant<PixelType, Rest...>> {
-  static void visit(UserFunc&& func, TRuntimeImage const& image) {
-    if (image.pixelType().template is<PixelType>()) {
-      func(image.template image<PixelType>());
+    typename TPixelType,
+    typename... TRest>
+struct VisitImpl<TUserFunc, TRuntimeImage, std::variant<TPixelType, TRest...>> {
+  static void visit(TUserFunc&& func, TRuntimeImage const& image) {
+    if (image.pixelType().template is<TPixelType>()) {
+      func(image.template image<TPixelType>());
     } else {
-      VisitImpl<UserFunc, TRuntimeImage, std::variant<Rest...>>::visit(
-          std::forward<UserFunc>(func), image);
+      VisitImpl<TUserFunc, TRuntimeImage, std::variant<TRest...>>::visit(
+          std::forward<TUserFunc>(func), image);
     }
   }
 };
 }  // namespace detail
 
 template <
-    typename UserFunc,
+    typename TUserFunc,
     class TPredicate = IntensityImagePredicate,
     template <typename> class TAllocator = Eigen::aligned_allocator>
 void visitImage(
-    UserFunc&& func, RuntimeImage<TPredicate, TAllocator> const& image) {
+    TUserFunc&& func, RuntimeImage<TPredicate, TAllocator> const& image) {
   using TRuntimeImage = RuntimeImage<TPredicate, TAllocator>;
   detail::
-      VisitImpl<UserFunc, TRuntimeImage, typename TPredicate::PixelVariant>::
-          visit(std::forward<UserFunc>(func), image);
+      VisitImpl<TUserFunc, TRuntimeImage, typename TPredicate::PixelVariant>::
+          visit(std::forward<TUserFunc>(func), image);
 }
 
 }  // namespace sophus

--- a/cpp/sophus/image/runtime_image_test.cpp
+++ b/cpp/sophus/image/runtime_image_test.cpp
@@ -253,19 +253,19 @@ TEST(IntensityImage, visitor) {
     IntensityImage<> runtime_image = ref_image;
     visitImage(
         farm_ng::Overload{
-            [&](Image<float> const& image) { FARM_CHECK(false); },
-            [&](Image<Pixel3U8> const& image) {
+            [&](Image<float> const&) { FARM_CHECK(false); },
+            [&](Image<Pixel3U8> const&) {
               // Should execute here
             },
-            [&](auto const& image) { FARM_CHECK(false); },
+            [&](auto const&) { FARM_CHECK(false); },
         },
         runtime_image);
 
     visitImage(
         farm_ng::Overload{
-            [&](Image<float> const& image) { FARM_CHECK(false); },
-            [&](Image<uint32_t> const& image) { FARM_CHECK(false); },
-            [&](auto const& image) {
+            [&](Image<float> const&) { FARM_CHECK(false); },
+            [&](Image<uint32_t> const&) { FARM_CHECK(false); },
+            [&](auto const&) {
               // Should execute here
             },
         },

--- a/cpp/sophus/image/runtime_image_test.cpp
+++ b/cpp/sophus/image/runtime_image_test.cpp
@@ -209,7 +209,7 @@ TEST(IntensityImage, visitor) {
     Image<float> ref_image = std::move(mut_image);
     IntensityImage<> runtime_image = ref_image;
 
-    visit(
+    visitImage(
         [&](auto const& image) {
           using Timg = typename std::remove_reference<decltype(image)>::type;
           using TPixel = typename Timg::PixelType;
@@ -231,7 +231,7 @@ TEST(IntensityImage, visitor) {
     Image<Pixel3U8> ref_image = std::move(mut_image);
     IntensityImage<> runtime_image = ref_image;
 
-    visit(
+    visitImage(
         [&](auto const& image) {
           using Timg = typename std::remove_reference<decltype(image)>::type;
           using TPixel = typename Timg::PixelType;
@@ -251,7 +251,7 @@ TEST(IntensityImage, visitor) {
     }
     Image<Pixel3U8> ref_image = std::move(mut_image);
     IntensityImage<> runtime_image = ref_image;
-    visit(
+    visitImage(
         farm_ng::Overload{
             [&](Image<float> const& image) { FARM_CHECK(false); },
             [&](Image<Pixel3U8> const& image) {
@@ -261,7 +261,7 @@ TEST(IntensityImage, visitor) {
         },
         runtime_image);
 
-    visit(
+    visitImage(
         farm_ng::Overload{
             [&](Image<float> const& image) { FARM_CHECK(false); },
             [&](Image<uint32_t> const& image) { FARM_CHECK(false); },

--- a/cpp/sophus/image/runtime_image_test.cpp
+++ b/cpp/sophus/image/runtime_image_test.cpp
@@ -9,6 +9,7 @@
 #include "sophus/image/runtime_image.h"
 
 #include <farm_ng/core/logging/logger.h>
+#include <farm_ng/core/misc/variant_utils.h>
 #include <gtest/gtest.h>
 
 using namespace sophus;
@@ -194,4 +195,80 @@ TEST(ClassHierarchy, call_function) {
 
   // won't compile, since Image is a ImageView but not a MutImageView:
   // plusOne(image);
+}
+
+TEST(IntensityImage, visitor) {
+  {
+    MutImage<float> mut_image(ImageSize(4, 4));
+    for (int y = 0; y < 4; ++y) {
+      for (int x = 0; x < 4; ++x) {
+        mut_image.uncheckedMut(x, y) = 4 * y + x;
+      }
+    }
+
+    Image<float> ref_image = std::move(mut_image);
+    IntensityImage<> runtime_image = ref_image;
+
+    visit(
+        [&](auto const& image) {
+          using Timg = typename std::remove_reference<decltype(image)>::type;
+          using TPixel = typename Timg::PixelType;
+          FARM_CHECK(runtime_image.template has<TPixel>());
+          if constexpr (std::is_same_v<TPixel, float>) {
+            FARM_CHECK(image.hasSameData(ref_image));
+          }
+        },
+        runtime_image);
+  }
+
+  {
+    MutImage<Pixel3U8> mut_image(ImageSize(4, 4));
+    for (int y = 0; y < 4; ++y) {
+      for (int x = 0; x < 4; ++x) {
+        mut_image.uncheckedMut(x, y) = Pixel3U8(x, y, 1);
+      }
+    }
+    Image<Pixel3U8> ref_image = std::move(mut_image);
+    IntensityImage<> runtime_image = ref_image;
+
+    visit(
+        [&](auto const& image) {
+          using Timg = typename std::remove_reference<decltype(image)>::type;
+          using TPixel = typename Timg::PixelType;
+          FARM_CHECK(runtime_image.template has<TPixel>());
+          if constexpr (std::is_same_v<TPixel, Pixel3U8>) {
+            FARM_CHECK(image.hasSameData(ref_image));
+          }
+        },
+        runtime_image);
+  }
+  {
+    MutImage<Pixel3U8> mut_image(ImageSize(4, 4));
+    for (int y = 0; y < 4; ++y) {
+      for (int x = 0; x < 4; ++x) {
+        mut_image.uncheckedMut(x, y) = Pixel3U8(x, y, 1);
+      }
+    }
+    Image<Pixel3U8> ref_image = std::move(mut_image);
+    IntensityImage<> runtime_image = ref_image;
+    visit(
+        farm_ng::Overload{
+            [&](Image<float> const& image) { FARM_CHECK(false); },
+            [&](Image<Pixel3U8> const& image) {
+              // Should execute here
+            },
+            [&](auto const& image) { FARM_CHECK(false); },
+        },
+        runtime_image);
+
+    visit(
+        farm_ng::Overload{
+            [&](Image<float> const& image) { FARM_CHECK(false); },
+            [&](Image<uint32_t> const& image) { FARM_CHECK(false); },
+            [&](auto const& image) {
+              // Should execute here
+            },
+        },
+        runtime_image);
+  }
 }

--- a/cpp/sophus/image/runtime_image_test.cpp
+++ b/cpp/sophus/image/runtime_image_test.cpp
@@ -253,19 +253,19 @@ TEST(IntensityImage, visitor) {
     IntensityImage<> runtime_image = ref_image;
     visitImage(
         farm_ng::Overload{
-            [&](Image<float> const&) { FARM_CHECK(false); },
-            [&](Image<Pixel3U8> const&) {
+            [&](Image<float> const& /*unused*/) { FARM_CHECK(false); },
+            [&](Image<Pixel3U8> const& /*unused*/) {
               // Should execute here
             },
-            [&](auto const&) { FARM_CHECK(false); },
+            [&](auto const& /*unused*/) { FARM_CHECK(false); },
         },
         runtime_image);
 
     visitImage(
         farm_ng::Overload{
-            [&](Image<float> const&) { FARM_CHECK(false); },
-            [&](Image<uint32_t> const&) { FARM_CHECK(false); },
-            [&](auto const&) {
+            [&](Image<float> const& /*unused*/) { FARM_CHECK(false); },
+            [&](Image<uint32_t> const& /*unused*/) { FARM_CHECK(false); },
+            [&](auto const& /*unused*/) {
               // Should execute here
             },
         },

--- a/scripts/install_ci_deps_mac.sh
+++ b/scripts/install_ci_deps_mac.sh
@@ -3,7 +3,4 @@
 set -x # echo on
 set -e # exit on error
 
-wget https://github.com/macports/macports-base/releases/download/v2.7.1/MacPorts-2.7.1-11-BigSur.pkg
-sudo installer -pkg ./MacPorts-2.7.1-11-BigSur.pkg -target /
-export PATH=/opt/local/bin:/opt/local/sbin:$PATH
-sudo PATH=$PATH port install protobuf3-cpp google-glog
+brew install --verbose ceres-solver pre-commit ccache glog protobuf grpc

--- a/scripts/install_local_deps_mac.sh
+++ b/scripts/install_local_deps_mac.sh
@@ -3,4 +3,4 @@
 set -x # echo on
 set -e # exit on error
 
-sudo port install cmake protobuf3-cpp ccache pre-commit google-glog
+brew install --verbose ceres-solver pre-commit ccache glog protobuf grpc

--- a/scripts/run_cpp_tests.sh
+++ b/scripts/run_cpp_tests.sh
@@ -6,7 +6,7 @@ set -e # exit on error
 cd super_project
 mkdir -p build
 cd build
-cmake -DROW_ACCESS=$ROW_ACCESS -DSUPER_PROJ_FARM_NG_PROTOS=$BUILD_PROTOS ..
+cmake -DROW_ACCESS=$ROW_ACCESS -DSUPER_PROJ_FARM_NG_PROTOS=$BUILD_PROTOS --debug-find ..
 make -j2
 
 # The make runs the tests in each of the projects built


### PR DESCRIPTION
Supported for RuntimeImages using a Variant based ImagePredicate.
Doing this required a small change to the predicate pattern such that the predicate is an non templated struct with a templated static method. This allows querying the variant type without hitting the static assert or needing a particular PixelType to query.