### PR TITLE
Unify on https remote urls for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,10 +12,10 @@
 	url = https://gitlab.com/libeigen/eigen.git
 [submodule "infra/ci-submodules/farm-ng-core"]
 	path = infra/ci-submodules/farm-ng-core
-	url = git@github.com:farm-ng/farm-ng-core.git
+	url = https://github.com/farm-ng/farm-ng-core.git
 [submodule "infra/ci-submodules/farm-ng-cmake"]
 	path = infra/ci-submodules/farm-ng-cmake
-	url = git@github.com:farm-ng/farm-ng-cmake.git
+	url = https://github.com/farm-ng/farm-ng-cmake.git
 [submodule "infra/ci-submodules/expected"]
 	path = infra/ci-submodules/expected
 	url = https://github.com/TartanLlama/expected.git
@@ -24,4 +24,4 @@
 	url = https://github.com/fmtlib/fmt.git
 [submodule "sophus-rs"]
 	path = sophus-rs
-	url = git@github.com:strasdat/sophus-rs.git
+	url = https://github.com/strasdat/sophus-rs.git


### PR DESCRIPTION
This makes it easier for CI in consuming projects to clone without SSH. 

If you already have the project checked out before this change, you may need to run `git submodule sync` to see this change take effect. Though most users wouldn't notice a difference, this is really to support CI systems. 