### PR TITLE
Add convenience assignment operators for subgroups of rxso3 and sim3.

### DIFF
--- a/cpp/sophus/lie/rxso3.h
+++ b/cpp/sophus/lie/rxso3.h
@@ -241,6 +241,15 @@ class RxSo3Base {
     return *this;
   }
 
+  /// Assignment-like operator from subgroup SO3 OtherDerived.
+  ///
+  template <class TOtherDerived>
+  SOPHUS_FUNC RxSo3Base<TDerived>& operator=(
+      So3Base<TOtherDerived> const& other) {
+    quaternionNonconst() = other.unitQuaternion();
+    return *this;
+  }
+
   /// Group multiplication, which is rotation concatenation and scale
   /// multiplication.
   ///

--- a/cpp/sophus/lie/sim3.h
+++ b/cpp/sophus/lie/sim3.h
@@ -13,6 +13,7 @@
 
 #include "sophus/lie/details/sim_impl.h"
 #include "sophus/lie/rxso3.h"
+#include "sophus/lie/se3.h"
 
 namespace sophus {
 template <class TScalar>
@@ -231,6 +232,16 @@ class Sim3Base {
   SOPHUS_FUNC Sim3Base<TDerived>& operator=(
       Sim3Base<TOtherDerived> const& other) {
     rxso3() = other.rxso3();
+    translation() = other.translation();
+    return *this;
+  }
+
+  /// Assignment-like operator from subgroup SE3 OtherDerived.
+  ///
+  template <class TOtherDerived>
+  SOPHUS_FUNC Sim3Base<TDerived>& operator=(
+      Se3Base<TOtherDerived> const& other) {
+    rxso3() = other.so3();
     translation() = other.translation();
     return *this;
   }


### PR DESCRIPTION
This is actually all I need, but perhaps it is odd to have assignment without constructor overload? I can add those too if you like.