### PR TITLE
Fix Windows build

### DIFF
--- a/sophus/common.hpp
+++ b/sophus/common.hpp
@@ -18,7 +18,7 @@
 #define SOPHUS_FMT_CSTR(description, ...) description
 #define SOPHUS_FMT_STR(description, ...) std::string(description)
 #define SOPHUS_FMT_PRINT(description, ...) std::printf("%s\n", description)
-#define SOPHUS_FMT_ARG(arg)
+#define SOPHUS_FMT_ARG(arg) arg
 
 #else  // !SOPHUS_USE_BASIC_LOGGING
 


### PR DESCRIPTION
And other probably too... since the original change (introduced in #376) does not work. 

As an example :

```cpp
#define SOPHUS_FMT_ARG(arg)

#else  // !SOPHUS_USE_BASIC_LOGGING
```

But later is fixed, thus, only works when using fmt:
```cpp
#if FMT_VERSION >= 90000
#define SOPHUS_FMT_ARG(arg) fmt::streamed(arg)
#else
#define SOPHUS_FMT_ARG(arg) arg
#endif
```

This PR fixes #394 and #436 