### PR TITLE
Make all `setRotationMatrix()` takes constant reference

### DIFF
--- a/sophus/sim2.hpp
+++ b/sophus/sim2.hpp
@@ -357,7 +357,7 @@ class Sim2Base {
 
   /// Setter of complex number using rotation matrix ``R``, leaves scale as is.
   ///
-  SOPHUS_FUNC void setRotationMatrix(Matrix2<Scalar>& R) {
+  SOPHUS_FUNC void setRotationMatrix(Matrix2<Scalar> const& R) {
     rxso2().setRotationMatrix(R);
   }
 

--- a/sophus/sim3.hpp
+++ b/sophus/sim3.hpp
@@ -355,7 +355,7 @@ class Sim3Base {
 
   /// Setter of quaternion using rotation matrix ``R``, leaves scale as is.
   ///
-  SOPHUS_FUNC void setRotationMatrix(Matrix3<Scalar>& R) {
+  SOPHUS_FUNC void setRotationMatrix(Matrix3<Scalar> const& R) {
     rxso3().setRotationMatrix(R);
   }
 


### PR DESCRIPTION
The functions setRotationMatrix() of Sim3 and Sim2 takes a reference instead of a constant reference (currently in Sim3):
```
void Sophus::Sim3Base< Derived >::setRotationMatrix(Matrix3<Scalar>& R);
```
Is there a particular reason? Because its implementation calls `rxso3().setRotationMatrix(R);`, which just needs a constant reference. Using a const reference would be more consistent and convenient. 