### PR TITLE
Fix SO2 when using ceres jet

### DIFF
--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -263,10 +263,8 @@ class SO2Base {
     Scalar const& real = unit_complex().x();
     Scalar const& imag = unit_complex().y();
     return HomogeneousPointProduct<HPointDerived>(
-        real * p[0] - imag * p[1],
-        imag * p[0] + real * p[1],
-        static_cast<ReturnScalar<HPointDerived>>(p[2])
-    );
+        real * p[0] - imag * p[1], imag * p[0] + real * p[1],
+        static_cast<ReturnScalar<HPointDerived>>(p[2]));
   }
 
   /// Group action on lines.

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -263,7 +263,10 @@ class SO2Base {
     Scalar const& real = unit_complex().x();
     Scalar const& imag = unit_complex().y();
     return HomogeneousPointProduct<HPointDerived>(
-        real * p[0] - imag * p[1], imag * p[0] + real * p[1], p[2]);
+        real * p[0] - imag * p[1],
+        imag * p[0] + real * p[1],
+        static_cast<ReturnScalar<HPointDerived>>(p[2])
+    );
   }
 
   /// Group action on lines.


### PR DESCRIPTION
The constructor of HomogeneousPointProduct expects the three argument to have same type, this is currently not the case when Scalar is a Ceres Jet type.