### PR TITLE
Adding a spline optimisation example in the test/ceres folder

### DIFF
--- a/test/ceres/ceres_flags.hpp
+++ b/test/ceres/ceres_flags.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+
+#include "gflags/gflags.h"
+
+
+DEFINE_bool(robustify_trilateration, false, "Use a robust loss function for trilateration.");
+
+DEFINE_string(trust_region_strategy, "levenberg_marquardt",
+        "Options are: levenberg_marquardt, dogleg.");
+DEFINE_string(dogleg, "traditional_dogleg", "Options are: traditional_dogleg,"
+        "subspace_dogleg.");
+
+DEFINE_bool(inner_iterations, false, "Use inner iterations to non-linearly "
+        "refine each successful trust region step.");
+
+DEFINE_string(blocks_for_inner_iterations, "automatic", "Options are: "
+        "automatic, cameras, points, cameras,points, points,cameras");
+
+DEFINE_string(linear_solver, "sparse_normal_cholesky", "Options are: "
+        "sparse_schur, dense_schur, iterative_schur, sparse_normal_cholesky, "
+        "dense_qr, dense_normal_cholesky and cgnr.");
+
+DEFINE_string(preconditioner, "jacobi", "Options are: "
+        "identity, jacobi, schur_jacobi, cluster_jacobi, "
+        "cluster_tridiagonal.");
+
+DEFINE_string(sparse_linear_algebra_library, "suite_sparse",
+        "Options are: suite_sparse and cx_sparse.");
+
+DEFINE_string(ordering, "automatic", "Options are: automatic, user.");
+
+DEFINE_bool(nonmonotonic_steps, false, "Trust region algorithm can use"
+        " nonmonotic steps.");
+

--- a/test/ceres/test_ceres_rxso2.cpp
+++ b/test/ceres/test_ceres_rxso2.cpp
@@ -51,6 +51,8 @@ int main(int, char **) {
   test.testAll();
 
 
+#if 0
+  // Example code to output the spline curve into a plottable format
   std::shared_ptr<Sophus::BasisSpline<RxSO2d>> so2_spline = test.testSpline(6);
   std::ofstream control("ctrl_pts", std::ofstream::out);
   for (size_t i=0;i<rxso2_vec.size();i++) {
@@ -63,6 +65,6 @@ int main(int, char **) {
       inter << t << " " << g.log().transpose() << std::endl;
   }
   inter.close();
-
+#endif
   return 0;
 }

--- a/test/ceres/test_ceres_rxso2.cpp
+++ b/test/ceres/test_ceres_rxso2.cpp
@@ -1,5 +1,6 @@
 #include <ceres/ceres.h>
 #include <iostream>
+#include <fstream>
 #include <sophus/rxso2.hpp>
 
 #include "tests.hpp"
@@ -46,6 +47,22 @@ int main(int, char **) {
   point_vec.push_back(Point(5.8, 9.2));
 
   std::cerr << "Test Ceres RxSO2" << std::endl;
-  Sophus::LieGroupCeresTests<Sophus::RxSO2>(rxso2_vec, point_vec).testAll();
+  Sophus::LieGroupCeresTests<Sophus::RxSO2> test(rxso2_vec, point_vec);
+  test.testAll();
+
+
+  std::shared_ptr<Sophus::BasisSpline<RxSO2d>> so2_spline = test.testSpline(6);
+  std::ofstream control("ctrl_pts", std::ofstream::out);
+  for (size_t i=0;i<rxso2_vec.size();i++) {
+      control << i << " " << rxso2_vec[i].log().transpose() << std::endl;
+  }
+  control.close();
+  std::ofstream inter("inter_pts", std::ofstream::out);
+  for (double t=0;t<rxso2_vec.size();t+=0.1) {
+      RxSO2d g = so2_spline->parent_T_spline(t);
+      inter << t << " " << g.log().transpose() << std::endl;
+  }
+  inter.close();
+
   return 0;
 }

--- a/test/ceres/test_ceres_so2.cpp
+++ b/test/ceres/test_ceres_so2.cpp
@@ -1,5 +1,6 @@
 #include <ceres/ceres.h>
 #include <iostream>
+#include <fstream>
 #include <sophus/so2.hpp>
 
 #include "tests.hpp"
@@ -40,6 +41,24 @@ int main(int, char **) {
   point_vec.emplace_back(Point(5.8, 9.2));
 
   std::cerr << "Test Ceres SO2" << std::endl;
-  Sophus::LieGroupCeresTests<Sophus::SO2>(so2_vec, point_vec).testAll();
+  Sophus::LieGroupCeresTests<Sophus::SO2> test(so2_vec, point_vec);
+  test.testAll();
+
+#if 0
+  // Example code to plot the interpolated spline
+  std::shared_ptr<Sophus::BasisSpline<SO2d>> so2_spline = test.testSpline(6);
+  std::ofstream control("ctrl_pts", std::ofstream::out);
+  for (size_t i=0;i<so2_vec.size();i++) {
+      control << i << " " << so2_vec[i].log() << std::endl;
+  }
+  control.close();
+  std::ofstream inter("inter_pts", std::ofstream::out);
+  for (double t=0;t<so2_vec.size();t+=0.1) {
+      SO2d g = so2_spline->parent_T_spline(t);
+      inter << t << " " << g.log() << std::endl;
+  }
+  inter.close();
+#endif
+
   return 0;
 }


### PR DESCRIPTION
I was missing an example of using Ceres with the spline structure and Sophus element, in a continuous-time fashion. The test code adds this example and shows how to optimize the spline knots based on measurements at arbitrary times. 