### PR TITLE
Reduce Eigen/Dense to Eigen/Core in sophus/rotation_matrix.hpp

### DIFF
--- a/sophus/rotation_matrix.hpp
+++ b/sophus/rotation_matrix.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <Eigen/Dense>
+#include <Eigen/Core>
 #include <Eigen/SVD>
 
 #include "types.hpp"


### PR DESCRIPTION
`Eigen/Dense` contains `Eigen/Core`, `Eigne/Geometry`, `SVD`, etc, which is much expensive to include.

By reducing `Eigen/Dense` to `Eigen/Core` in `sophus/rotation_matrix.hpp`, we can avoid unnecessary headers when using `se3.hpp`, `so3.hpp`, or `rotation_matrix.hpp`. This would help to reduce compilation time for Sophus' users with a large codebase.