### PR TITLE
Support building with Eigen3 5.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,11 +34,6 @@ jobs:
             ensure: default_panic
             compiler: gcc
           - test: unit_tests
-            os: macos-13
-            access: col_major
-            ensure: default_panic
-            compiler: clang
-          - test: unit_tests
             os: macos-14
             access: col_major
             ensure: default_panic
@@ -95,7 +90,7 @@ jobs:
 
       - name: Install dependencies (Mac OS incl. Ceres)
         run: ./scripts/install_osx_deps_incl_ceres.sh
-        if: matrix.os == 'macos-14' || matrix.os == 'macos-13'
+        if: matrix.os == 'macos-14'
 
       - name: Build (gcc) and run tests
         run: ./scripts/run_cpp_tests_gcc.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,10 @@ endif()
 # example defined by a parent project including Sophus via `add_subdirectory`.)
 
 if(NOT TARGET Eigen3::Eigen)
-  find_package(Eigen3 3.4.0 REQUIRED)
+  find_package(Eigen3 3.4...5 QUIET)
+  if(NOT Eigen3_FOUND)
+    find_package(Eigen3 3.4.0 REQUIRED)
+  endif()
 endif()
 
 # Define interface library target

--- a/scripts/install_osx_deps_incl_ceres.sh
+++ b/scripts/install_osx_deps_incl_ceres.sh
@@ -7,10 +7,12 @@ brew update
 brew install ccache
 
 # Get dependencies for Ceres Solver
+brew install abseil
 brew install eigen
 brew install gflags
 brew install glog
 brew install gcc
+brew install googletest
 brew install openblas
 brew install libomp
 brew install hwloc
@@ -18,7 +20,7 @@ brew install tbb
 
 git clone https://ceres-solver.googlesource.com/ceres-solver ceres-solver
 cd ceres-solver
-git reset --hard 6a74af202d83cf31811ea17dc66c74d03b89d79e
+git reset --hard f9b7b6651b108136a16df44d91fb31735645f5a7
 mkdir target
 cd target
 ls


### PR DESCRIPTION
Original find_package usage cannot find `Eigen3 >= 5`.

Using a range can help as mentioned in https://libeigen.gitlab.io/eigen/docs-5.0/TopicCMakeGuide.html
> `find_package(Eigen3 3.4...5 REQUIRED NO_MODULE)  # Any version >=3.4.1 but <6.0.0.`

However, it still needs a fallback to find 3.4.0.

---

EDIT: An alternative could be to run find_package unversioned and follow up with a manual version check